### PR TITLE
feat: add optional colored log output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "colored",
  "fast-glob",
  "futures",
  "git2",

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ license agreements:
   Dual-licensed under [Apache 2.0][Apache2] or [MIT].
 - [chrono](https://crates.io/crates/chrono):
   Dual-licensed under [Apache 2.0][Apache2] or [MIT].
+- [colored](https://crates.io/crates/colored): Licensed under [MPL-2.0]
 
 The python binding uses
 
@@ -223,3 +224,4 @@ The node binding uses
 
 [MIT]: https://choosealicense.com/licenses/mit
 [Apache2]: https://choosealicense.com/licenses/apache-2.0/
+[MPL-2.0]: https://choosealicense.com/licenses/mpl-2.0

--- a/cpp-linter/Cargo.toml
+++ b/cpp-linter/Cargo.toml
@@ -17,11 +17,12 @@ license.workspace = true
 anyhow = "1.0.89"
 chrono = "0.4.38"
 clap = "4.5.17"
+colored = "2.1.0"
 fast-glob = "0.4.0"
 futures = "0.3.30"
 git2 = "0.19.0"
 lenient_semver = "0.4.2"
-log = "0.4.22"
+log = { version = "0.4.22", features = ["std"] }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 openssl-probe = { version = "0.1", optional = true }
 regex = "1.10.6"

--- a/cpp-linter/src/clang_tools/mod.rs
+++ b/cpp-linter/src/clang_tools/mod.rs
@@ -21,8 +21,7 @@ use which::{which, which_in};
 use super::common_fs::FileObj;
 use crate::{
     cli::ClangParams,
-    logger::{end_log_group, start_log_group},
-    rest_api::{COMMENT_MARKER, USER_OUTREACH},
+    rest_api::{RestApiClient, COMMENT_MARKER, USER_OUTREACH},
 };
 pub mod clang_format;
 use clang_format::run_clang_format;
@@ -144,6 +143,7 @@ pub async fn capture_clang_tools_output(
     files: &mut Vec<Arc<Mutex<FileObj>>>,
     version: &str,
     clang_params: &mut ClangParams,
+    rest_api_client: &impl RestApiClient,
 ) -> Result<()> {
     // find the executable paths for clang-tidy and/or clang-format and show version
     // info as debugging output.
@@ -192,11 +192,11 @@ pub async fn capture_clang_tools_output(
     while let Some(output) = executors.join_next().await {
         if let Ok(out) = output? {
             let (file_name, logs) = out;
-            start_log_group(format!("Analyzing {}", file_name.to_string_lossy()));
+            rest_api_client.start_log_group(format!("Analyzing {}", file_name.to_string_lossy()));
             for (level, msg) in logs {
                 log::log!(level, "{}", msg);
             }
-            end_log_group();
+            rest_api_client.end_log_group();
         }
     }
     Ok(())

--- a/cpp-linter/src/logger.rs
+++ b/cpp-linter/src/logger.rs
@@ -24,7 +24,7 @@ impl SimpleLogger {
 
 impl log::Log for SimpleLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
-        metadata.level() <= Level::Debug
+        metadata.level() <= log::max_level()
     }
 
     fn log(&self, record: &Record) {

--- a/cpp-linter/src/logger.rs
+++ b/cpp-linter/src/logger.rs
@@ -49,7 +49,10 @@ impl log::Log for SimpleLogger {
 /// Returns a [`SetLoggerError`] if the `LOGGER` is already initialized.
 pub fn init() -> Result<()> {
     let logger: SimpleLogger = SimpleLogger;
-    if env::var("CPP_LINTER_COLOR").is_ok_and(|v| ["on", "1", "true"].contains(&v.as_str())) {
+    if matches!(
+        env::var("CPP_LINTER_COLOR").as_deref(),
+        Ok("on" | "1" | "true")
+    ) {
         set_override(true);
     }
     log::set_boxed_logger(Box::new(logger))

--- a/cpp-linter/src/rest_api/github/mod.rs
+++ b/cpp-linter/src/rest_api/github/mod.rs
@@ -95,6 +95,16 @@ impl RestApiClient for GithubApiClient {
         checks_failed
     }
 
+    /// This prints a line to indicate the beginning of a related group of log statements.
+    fn start_log_group(&self, name: String) {
+        log::info!(target: "CI_LOG_GROUPING", "::group::{}", name);
+    }
+
+    /// This prints a line to indicate the ending of a related group of log statements.
+    fn end_log_group(&self) {
+        log::info!(target: "CI_LOG_GROUPING", "::endgroup::");
+    }
+
     fn make_headers() -> Result<HeaderMap<HeaderValue>> {
         let mut headers = HeaderMap::new();
         headers.insert(


### PR DESCRIPTION
Uses a new dependency [`colored`](https://crates.io/crates/colored) to get cross-platform compatible for terminal colors. Supports an environment variable `CPP_LINTER_COLOR` that (if set to `1`, `on`, or `true`) will force color output when it is automatically disabled (see [`colored` features](https://github.com/colored-rs/colored#features) which follows [standards](http://bixense.com/clicolors)).

I also moved the log grouping functions into the `rest_api` module. Technically, the log grouping commands we currently use are specific to GitHub. Other Git servers (like [GitLab](https://docs.gitlab.com/ee/ci/yaml/script.html#custom-collapsible-sections)) implement these differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new dependency, `colored`, enhancing log message visibility with color coding.
  - Added logging methods `start_log_group` and `end_log_group` to improve log organization within the API client.

- **Bug Fixes**
  - Improved logging functionality by integrating the `GithubApiClient` for better feedback management.

- **Documentation**
  - Updated `README.md` to reflect the addition of the new `colored` dependency and its license information.

- **Chores**
  - Refined the logging process across various modules to utilize the new API client for logging operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->