### PR TITLE
feat: capture and output clang tool's version number

### DIFF
--- a/cpp-linter/src/clang_tools/mod.rs
+++ b/cpp-linter/src/clang_tools/mod.rs
@@ -13,6 +13,7 @@ use anyhow::{anyhow, Context, Result};
 use git2::{DiffOptions, Patch};
 // non-std crates
 use lenient_semver;
+use regex::Regex;
 use semver::Version;
 use tokio::task::JoinSet;
 use which::{which, which_in};
@@ -135,6 +136,28 @@ fn analyze_single_file(
     Ok((file.name.clone(), logs))
 }
 
+/// A struct to contain the version numbers of the clang-tools used
+#[derive(Default)]
+pub struct ClangVersions {
+    /// The clang-format version used.
+    pub format_version: Option<String>,
+
+    /// The clang-tidy version used.
+    pub tidy_version: Option<String>,
+}
+
+/// Run `clang-tool --version`, the extract and return the version number.
+fn capture_clang_version(clang_tool: &PathBuf) -> Result<String> {
+    let output = Command::new(clang_tool).arg("--version").output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let version_pattern = Regex::new(r"version\s*(\d+\.\d+\.\d+)").unwrap();
+    let captures = version_pattern.captures(&stdout).ok_or(anyhow!(
+        "Failed to find version number in `{} --version` output",
+        clang_tool.to_string_lossy()
+    ))?;
+    Ok(captures.get(1).unwrap().as_str().to_string())
+}
+
 /// Runs clang-tidy and/or clang-format and returns the parsed output from each.
 ///
 /// If `tidy_checks` is `"-*"` then clang-tidy is not executed.
@@ -144,30 +167,29 @@ pub async fn capture_clang_tools_output(
     version: &str,
     clang_params: &mut ClangParams,
     rest_api_client: &impl RestApiClient,
-) -> Result<()> {
+) -> Result<ClangVersions> {
+    let mut clang_versions = ClangVersions::default();
     // find the executable paths for clang-tidy and/or clang-format and show version
     // info as debugging output.
     if clang_params.tidy_checks != "-*" {
-        clang_params.clang_tidy_command = {
-            let cmd = get_clang_tool_exe("clang-tidy", version)?;
-            log::debug!(
-                "{} --version\n{}",
-                &cmd.to_string_lossy(),
-                String::from_utf8_lossy(&Command::new(&cmd).arg("--version").output()?.stdout)
-            );
-            Some(cmd)
-        }
+        let exe_path = get_clang_tool_exe("clang-tidy", version)?;
+        let version_found = capture_clang_version(&exe_path)?;
+        log::debug!(
+            "{} --version: v{version_found}",
+            &exe_path.to_string_lossy()
+        );
+        clang_versions.tidy_version = Some(version_found);
+        clang_params.clang_tidy_command = Some(exe_path);
     };
     if !clang_params.style.is_empty() {
-        clang_params.clang_format_command = {
-            let cmd = get_clang_tool_exe("clang-format", version)?;
-            log::debug!(
-                "{} --version\n{}",
-                &cmd.to_string_lossy(),
-                String::from_utf8_lossy(&Command::new(&cmd).arg("--version").output()?.stdout)
-            );
-            Some(cmd)
-        }
+        let exe_path = get_clang_tool_exe("clang-format", version)?;
+        let version_found = capture_clang_version(&exe_path)?;
+        log::debug!(
+            "{} --version: v{version_found}",
+            &exe_path.to_string_lossy()
+        );
+        clang_versions.format_version = Some(version_found);
+        clang_params.clang_format_command = Some(exe_path);
     };
 
     // parse database (if provided) to match filenames when parsing clang-tidy's stdout
@@ -199,7 +221,7 @@ pub async fn capture_clang_tools_output(
             rest_api_client.end_log_group();
         }
     }
-    Ok(())
+    Ok(clang_versions)
 }
 
 /// A struct to describe a single suggestion in a pull_request review.
@@ -221,7 +243,7 @@ pub struct ReviewComments {
     ///
     /// This differs from `comments.len()` because some suggestions may
     /// not fit within the file's diff.
-    pub tool_total: [u32; 2],
+    pub tool_total: [Option<u32>; 2],
     /// A list of comment suggestions to be posted.
     ///
     /// These suggestions are guaranteed to fit in the file's diff.
@@ -234,11 +256,26 @@ pub struct ReviewComments {
 }
 
 impl ReviewComments {
-    pub fn summarize(&self) -> String {
+    pub fn summarize(&self, clang_versions: &ClangVersions) -> String {
         let mut body = format!("{COMMENT_MARKER}## Cpp-linter Review\n");
         for t in 0u8..=1 {
             let mut total = 0;
-            let tool_name = if t == 0 { "clang-format" } else { "clang-tidy" };
+            let (tool_name, tool_version) = if t == 0 {
+                ("clang-format", clang_versions.format_version.as_ref())
+            } else {
+                ("clang-tidy", clang_versions.tidy_version.as_ref())
+            };
+
+            if self.tool_total[t as usize].is_none() {
+                // review was not requested from this tool or the tool was not used at all
+                continue;
+            }
+
+            // If the tool's version is unknown, then we don't need to output this line.
+            // NOTE: If the tool was invoked at all, then the tool's version shall be known.
+            if let Some(ver_str) = tool_version {
+                body.push_str(format!("### Used {tool_name} {ver_str}\n").as_str());
+            }
             for comment in &self.comments {
                 if comment
                     .suggestion
@@ -248,11 +285,12 @@ impl ReviewComments {
                 }
             }
 
-            if total != self.tool_total[t as usize] {
+            // at this point tool_total is Some() value; unwrap() is safe here
+            let tool_total = self.tool_total[t as usize].unwrap();
+            if total != tool_total {
                 body.push_str(
                     format!(
-                        "\nOnly {} out of {} {tool_name} concerns fit within this pull request's diff.\n",
-                        self.tool_total[t as usize], total
+                        "\nOnly {total} out of {tool_total} {tool_name} concerns fit within this pull request's diff.\n",
                     )
                     .as_str(),
                 );
@@ -351,6 +389,9 @@ pub trait MakeSuggestions {
                 .with_context(|| format!("Failed to convert patch to string: {file_name}"))?
                 .as_str(),
         );
+        if review_comments.tool_total[is_tidy_tool as usize].is_none() {
+            review_comments.tool_total[is_tidy_tool as usize] = Some(0);
+        }
         if summary_only {
             return Ok(());
         }
@@ -408,7 +449,9 @@ pub trait MakeSuggestions {
                 review_comments.comments.push(comment);
             }
         }
-        review_comments.tool_total[is_tidy_tool as usize] += hunks_in_patch;
+        review_comments.tool_total[is_tidy_tool as usize] = Some(
+            review_comments.tool_total[is_tidy_tool as usize].unwrap_or_default() + hunks_in_patch,
+        );
         Ok(())
     }
 }

--- a/cpp-linter/src/clang_tools/mod.rs
+++ b/cpp-linter/src/clang_tools/mod.rs
@@ -150,7 +150,7 @@ pub struct ClangVersions {
 fn capture_clang_version(clang_tool: &PathBuf) -> Result<String> {
     let output = Command::new(clang_tool).arg("--version").output()?;
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let version_pattern = Regex::new(r"version\s*(\d+\.\d+\.\d+)").unwrap();
+    let version_pattern = Regex::new(r"(?i)version\s*([\d.]+)").unwrap();
     let captures = version_pattern.captures(&stdout).ok_or(anyhow!(
         "Failed to find version number in `{} --version` output",
         clang_tool.to_string_lossy()

--- a/cpp-linter/src/common_fs/mod.rs
+++ b/cpp-linter/src/common_fs/mod.rs
@@ -158,12 +158,12 @@ impl FileObj {
                 .unwrap_or_default()
                 .to_str()
                 .unwrap_or_default();
+            let mut total = 0;
             for note in &advice.notes {
                 if note.fixed_lines.is_empty() {
                     // notification had no suggestion applied in `patched`
                     let mut suggestion = format!(
-                        "### clang-tidy diagnostic\n**{}:{}:{}** {}: [{}]\n> {}",
-                        file_name,
+                        "### clang-tidy diagnostic\n**{file_name}:{}:{}** {}: [{}]\n> {}",
                         &note.line,
                         &note.cols,
                         &note.severity,
@@ -172,10 +172,10 @@ impl FileObj {
                     );
                     if !note.suggestion.is_empty() {
                         suggestion.push_str(
-                            format!("```{}\n{}```", file_ext, &note.suggestion.join("\n")).as_str(),
+                            format!("```{file_ext}\n{}```", &note.suggestion.join("\n")).as_str(),
                         );
                     }
-                    review_comments.tool_total[1] += 1;
+                    total += 1;
                     let mut is_merged = false;
                     for s in &mut review_comments.comments {
                         if s.path == file_name
@@ -197,6 +197,8 @@ impl FileObj {
                     }
                 }
             }
+            review_comments.tool_total[1] =
+                Some(review_comments.tool_total[1].unwrap_or_default() + total);
         }
         Ok(())
     }
@@ -308,14 +310,14 @@ mod test {
     // *********************** tests for FileObj::get_ranges()
 
     #[test]
-    fn get_ranges_0() {
+    fn get_ranges_none() {
         let file_obj = FileObj::new(PathBuf::from("tests/demo/demo.cpp"));
         let ranges = file_obj.get_ranges(&LinesChangedOnly::Off);
         assert!(ranges.is_empty());
     }
 
     #[test]
-    fn get_ranges_2() {
+    fn get_ranges_diff() {
         let diff_chunks = vec![1..=10];
         let added_lines = vec![4, 5, 9];
         let file_obj = FileObj::from(
@@ -328,7 +330,7 @@ mod test {
     }
 
     #[test]
-    fn get_ranges_1() {
+    fn get_ranges_added() {
         let diff_chunks = vec![1..=10];
         let added_lines = vec![4, 5, 9];
         let file_obj = FileObj::from(

--- a/cpp-linter/src/common_fs/mod.rs
+++ b/cpp-linter/src/common_fs/mod.rs
@@ -158,6 +158,7 @@ impl FileObj {
                 .unwrap_or_default()
                 .to_str()
                 .unwrap_or_default();
+            // Count of clang-tidy diagnostics that had no fixes applied
             let mut total = 0;
             for note in &advice.notes {
                 if note.fixed_lines.is_empty() {

--- a/cpp-linter/src/run.rs
+++ b/cpp-linter/src/run.rs
@@ -128,7 +128,7 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
 
     let mut clang_params = ClangParams::from(&cli);
     let user_inputs = FeedbackInput::from(&cli);
-    capture_clang_tools_output(
+    let clang_versions = capture_clang_tools_output(
         &mut arc_files,
         cli.version.as_str(),
         &mut clang_params,
@@ -137,7 +137,7 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
     .await?;
     rest_api_client.start_log_group(String::from("Posting feedback"));
     let checks_failed = rest_api_client
-        .post_feedback(&arc_files, user_inputs)
+        .post_feedback(&arc_files, user_inputs, clang_versions)
         .await?;
     rest_api_client.end_log_group();
     if env::var("PRE_COMMIT").is_ok_and(|v| v == "1") {

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -49,6 +49,7 @@ words:
   - revparse
   - serde
   - superfences
+  - tada
   - tasklist
   - tempdir
   - tempfile


### PR DESCRIPTION
This affects thread-comments, step-summary, and PR review summary.

I also added tests to ensure PR review summary only shows relevant information about the tools that were actually used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced version tracking for clang tools, enhancing feedback with version information.
	- Added a new function for generating tool summary messages based on review status.
	- Added new test cases for scenarios with only tidy or format reviews.

- **Bug Fixes**
	- Improved handling of clang-tidy diagnostics and suggestion formatting.

- **Documentation**
	- Updated test summaries to reflect changes in review flags.

- **Chores**
	- Added "tada" to the spell-check configuration for improved recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->