### PR TITLE
refactor: switch to `quick_xml` library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,11 +366,11 @@ dependencies = [
  "mockito",
  "openssl",
  "openssl-probe",
+ "quick-xml",
  "regex",
  "reqwest",
  "semver",
  "serde",
- "serde-xml-rs",
  "serde_json",
  "tempfile",
  "tokio",
@@ -1599,6 +1599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,18 +1897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-xml-rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3aa78ecda1ebc9ec9847d5d3aba7d618823446a049ba2491940506da6e2782"
-dependencies = [
- "log",
- "serde",
- "thiserror",
- "xml-rs",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,26 +2062,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2554,12 +2532,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
 
 [[package]]
 name = "yoke"

--- a/cpp-linter/Cargo.toml
+++ b/cpp-linter/Cargo.toml
@@ -25,11 +25,11 @@ lenient_semver = "0.4.2"
 log = { version = "0.4.25", features = ["std"] }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 openssl-probe = { version = "0.1", optional = true }
+quick-xml = {version = "0.37.2", features = ["serialize"]}
 regex = "1.11.1"
 reqwest = "0.12.12"
 semver = "1.0.25"
 serde = { version = "1.0.217", features = ["derive"] }
-serde-xml-rs = "0.6.0"
 serde_json = "1.0.137"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"]}
 tokio-macros = "2.4.0"

--- a/cpp-linter/src/clang_tools/clang_format.rs
+++ b/cpp-linter/src/clang_tools/clang_format.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use super::MakeSuggestions;
 use crate::{
     cli::ClangParams,
-    common_fs::{get_line_cols_from_offset, FileObj},
+    common_fs::{get_line_count_from_offset, FileObj},
 };
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -50,13 +50,6 @@ pub struct Replacement {
     /// deserialization.
     #[serde(default)]
     pub line: u32,
-
-    /// The column number on the line described by the [`Replacement::offset`].
-    ///
-    /// This value is not provided by the XML output, but we calculate it after
-    /// deserialization.
-    #[serde(default)]
-    pub cols: u32,
 }
 
 /// Get a string that summarizes the given `--style`
@@ -169,10 +162,8 @@ pub fn run_clang_format(
         // get line and column numbers from format_advice.offset
         let mut filtered_replacements = Vec::new();
         for replacement in &mut format_advice.replacements {
-            let (line_number, columns) =
-                get_line_cols_from_offset(&original_contents, replacement.offset);
+            let line_number = get_line_count_from_offset(&original_contents, replacement.offset);
             replacement.line = line_number;
-            replacement.cols = columns;
             for range in &ranges {
                 if range.contains(&line_number) {
                     filtered_replacements.push(*replacement);

--- a/cpp-linter/src/clang_tools/clang_tidy.rs
+++ b/cpp-linter/src/clang_tools/clang_tidy.rs
@@ -276,16 +276,17 @@ pub fn run_clang_tidy(
             cmd.args(["--line-filter", filter.as_str()]);
         }
     }
-    let mut original_content = None;
-    if clang_params.tidy_review {
+    let original_content = if !clang_params.tidy_review {
+        None
+    } else {
         cmd.arg("--fix-errors");
-        original_content = Some(fs::read_to_string(&file.name).with_context(|| {
+        Some(fs::read_to_string(&file.name).with_context(|| {
             format!(
                 "Failed to cache file's original content before applying clang-tidy changes: {}",
                 file_name.clone()
             )
-        })?);
-    }
+        })?)
+    };
     if !clang_params.style.is_empty() {
         cmd.args(["--format-style", clang_params.style.as_str()]);
     }

--- a/cpp-linter/src/clang_tools/mod.rs
+++ b/cpp-linter/src/clang_tools/mod.rs
@@ -258,20 +258,18 @@ pub struct ReviewComments {
 impl ReviewComments {
     pub fn summarize(&self, clang_versions: &ClangVersions) -> String {
         let mut body = format!("{COMMENT_MARKER}## Cpp-linter Review\n");
-        for t in 0u8..=1 {
+        for t in 0_usize..=1 {
             let mut total = 0;
             let (tool_name, tool_version) = if t == 0 {
                 ("clang-format", clang_versions.format_version.as_ref())
             } else {
                 ("clang-tidy", clang_versions.tidy_version.as_ref())
             };
-
-            let tool_total = if let Some(total) = self.tool_total[t as usize] {
-                total
-            } else {
-                // review was not requested from this tool or the tool was not used at all
+            if tool_version.is_none() {
+                // this tool was not used at all
                 continue;
-            };
+            }
+            let tool_total = self.tool_total[t].unwrap_or_default();
 
             // If the tool's version is unknown, then we don't need to output this line.
             // NOTE: If the tool was invoked at all, then the tool's version shall be known.
@@ -295,11 +293,11 @@ impl ReviewComments {
                     .as_str(),
                 );
             }
-            if !self.full_patch[t as usize].is_empty() {
+            if !self.full_patch[t].is_empty() {
                 body.push_str(
                     format!(
                         "\n<details><summary>Click here for the full {tool_name} patch</summary>\n\n```diff\n{}```\n\n</details>\n",
-                        self.full_patch[t as usize]
+                        self.full_patch[t]
                     ).as_str()
                 );
             } else {
@@ -370,8 +368,7 @@ pub trait MakeSuggestions {
         patch: &mut Patch,
         summary_only: bool,
     ) -> Result<()> {
-        let tool_name = self.get_tool_name();
-        let is_tidy_tool = tool_name == "clang-tidy";
+        let is_tidy_tool = (&self.get_tool_name() == "clang-tidy") as usize;
         let hunks_total = patch.num_hunks();
         let mut hunks_in_patch = 0u32;
         let file_name = file_obj
@@ -384,13 +381,13 @@ pub trait MakeSuggestions {
             .to_buf()
             .with_context(|| "Failed to convert patch to byte array")?
             .to_vec();
-        review_comments.full_patch[is_tidy_tool as usize].push_str(
+        review_comments.full_patch[is_tidy_tool].push_str(
             String::from_utf8(patch_buf.to_owned())
                 .with_context(|| format!("Failed to convert patch to string: {file_name}"))?
                 .as_str(),
         );
-        review_comments.tool_total[is_tidy_tool as usize].get_or_insert(0);
         if summary_only {
+            review_comments.tool_total[is_tidy_tool].get_or_insert(0);
             return Ok(());
         }
         for hunk_id in 0..hunks_total {
@@ -447,9 +444,8 @@ pub trait MakeSuggestions {
                 review_comments.comments.push(comment);
             }
         }
-        review_comments.tool_total[is_tidy_tool as usize] = Some(
-            review_comments.tool_total[is_tidy_tool as usize].unwrap_or_default() + hunks_in_patch,
-        );
+        review_comments.tool_total[is_tidy_tool] =
+            Some(review_comments.tool_total[is_tidy_tool].unwrap_or_default() + hunks_in_patch);
         Ok(())
     }
 }

--- a/cpp-linter/src/common_fs/file_filter.rs
+++ b/cpp-linter/src/common_fs/file_filter.rs
@@ -111,7 +111,7 @@ impl FileFilter {
                 || (pat.is_dir() && file_name.starts_with(pat))
             {
                 log::debug!(
-                    "file {file_name:?} is in {}ignored with domain {pattern:?}.",
+                    "file {file_name:?} is {}ignored with domain {pattern:?}.",
                     if is_ignored { "" } else { "not " }
                 );
                 return true;

--- a/cpp-linter/src/common_fs/mod.rs
+++ b/cpp-linter/src/common_fs/mod.rs
@@ -227,11 +227,11 @@ impl FileObj {
 /// boundary exists at the returned column number. However, the `offset` given to this
 /// function is expected to originate from diagnostic information provided by
 /// clang-format or clang-tidy.
-pub fn get_line_cols_from_offset(contents: &[u8], offset: usize) -> (usize, usize) {
-    let lines = contents[0..offset].split(|byte| byte == &b'\n');
-    let line_count = lines.clone().count();
+pub fn get_line_cols_from_offset(contents: &[u8], offset: u32) -> (u32, u32) {
+    let lines = contents[0..offset as usize].split(|byte| byte == &b'\n');
+    let line_count = lines.clone().count() as u32;
     // here we `cols.len() + 1` because columns is not a 0-based count
-    let column_count = lines.last().map(|cols| cols.len() + 1).unwrap_or(1);
+    let column_count = lines.last().map(|cols| cols.len() + 1).unwrap_or(1) as u32;
     (line_count, column_count)
 }
 

--- a/cpp-linter/src/rest_api/github/mod.rs
+++ b/cpp-linter/src/rest_api/github/mod.rs
@@ -316,8 +316,6 @@ mod test {
                 });
                 let replacements = vec![Replacement {
                     offset: 0,
-                    length: 0,
-                    value: Some(String::new()),
                     line: 1,
                     cols: 1,
                 }];

--- a/cpp-linter/src/rest_api/github/mod.rs
+++ b/cpp-linter/src/rest_api/github/mod.rs
@@ -314,13 +314,8 @@ mod test {
                     notes,
                     patched: None,
                 });
-                let replacements = vec![Replacement {
-                    offset: 0,
-                    line: 1,
-                    cols: 1,
-                }];
                 file.format_advice = Some(FormatAdvice {
-                    replacements,
+                    replacements: vec![Replacement { offset: 0, line: 1 }],
                     patched: None,
                 });
                 files.push(Arc::new(Mutex::new(file)));

--- a/cpp-linter/src/rest_api/github/specific_api.rs
+++ b/cpp-linter/src/rest_api/github/specific_api.rs
@@ -169,7 +169,7 @@ impl GithubApiClient {
             let file = file.lock().unwrap();
             if let Some(format_advice) = &file.format_advice {
                 // assemble a list of line numbers
-                let mut lines: Vec<usize> = Vec::new();
+                let mut lines = Vec::new();
                 for replacement in &format_advice.replacements {
                     if !lines.contains(&replacement.line) {
                         lines.push(replacement.line);


### PR DESCRIPTION
- deserialize only what is needed from XML. `cols`, `length`, and `value` fields were never used and are now ignored when parsing XML
- read file contents only once when translating byte offset to line ~and columns~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Changes**
  - Added `quick-xml` library with serialization support
  - Removed `serde-xml-rs` dependency

- **Code Improvements**
  - Updated XML parsing and deserialization strategy
  - Refined line number calculation methods
  - Enhanced GitHub API client feedback posting logic

- **Performance**
  - Optimized file content processing
  - Improved error handling for XML serialization

- **Logging Enhancements**
  - Clarified log messages in file filtering checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->