### PR TITLE
Fix inf test ci

### DIFF
--- a/cpp-linter/src/common_fs/file_filter.rs
+++ b/cpp-linter/src/common_fs/file_filter.rs
@@ -61,7 +61,8 @@ impl FileFilter {
             for line in read_buf.split('\n') {
                 if line.trim_start().starts_with("path") {
                     assert!(line.find('=').unwrap() > 0);
-                    let submodule = String::from("./") + line.split('=').last().unwrap().trim();
+                    let submodule =
+                        String::from("./") + line.split('=').next_back().unwrap().trim();
                     log::debug!("Found submodule: {submodule}");
                     let mut is_ignored = true;
                     for pat in &self.not_ignored {
@@ -159,7 +160,7 @@ impl FileFilter {
                 let mut is_hidden = false;
                 let parent = path
                     .components()
-                    .last()
+                    .next_back()
                     .ok_or(anyhow!("parent directory not known for {path:?}"))?;
                 if parent.as_os_str().to_str().unwrap().starts_with('.') {
                     is_hidden = true;

--- a/cpp-linter/src/run.rs
+++ b/cpp-linter/src/run.rs
@@ -159,10 +159,19 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
 mod test {
     use super::run_main;
     use std::env;
+    use tempfile::NamedTempFile;
+
+    /// Avoid writing to GITHUB_OUTPUT in parallel-running tests.
+    ///
+    /// This simply creates a temp file and sets the env var, GITHUB_OUTPUT, to the temp file's path.
+    fn monkey_patch_gh_output() {
+        let fake_gh_out = NamedTempFile::new().unwrap();
+        env::set_var("GITHUB_OUTPUT", fake_gh_out.path());
+    }
 
     #[tokio::test]
     async fn normal() {
-        env::remove_var("GITHUB_OUTPUT"); // avoid writing to GH_OUT in parallel-running tests
+        monkey_patch_gh_output();
         let result = run_main(vec![
             "cpp-linter".to_string(),
             "-l".to_string(),
@@ -177,14 +186,14 @@ mod test {
 
     #[tokio::test]
     async fn version_command() {
-        env::remove_var("GITHUB_OUTPUT"); // avoid writing to GH_OUT in parallel-running tests
+        monkey_patch_gh_output();
         let result = run_main(vec!["cpp-linter".to_string(), "version".to_string()]).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn force_debug_output() {
-        env::remove_var("GITHUB_OUTPUT"); // avoid writing to GH_OUT in parallel-running tests
+        monkey_patch_gh_output();
         let result = run_main(vec![
             "cpp-linter".to_string(),
             "-l".to_string(),
@@ -199,7 +208,7 @@ mod test {
 
     #[tokio::test]
     async fn bad_version_input() {
-        env::remove_var("GITHUB_OUTPUT"); // avoid writing to GH_OUT in parallel-running tests
+        monkey_patch_gh_output();
         let result = run_main(vec![
             "cpp-linter".to_string(),
             "-l".to_string(),
@@ -212,7 +221,7 @@ mod test {
 
     #[tokio::test]
     async fn pre_commit_env() {
-        env::remove_var("GITHUB_OUTPUT"); // avoid writing to GH_OUT in parallel-running tests
+        monkey_patch_gh_output();
         env::set_var("PRE_COMMIT", "1");
         let result = run_main(vec![
             "cpp-linter".to_string(),
@@ -228,7 +237,7 @@ mod test {
     // This ensures no diagnostic comments are generated when analysis is explicitly skipped.
     #[tokio::test]
     async fn no_analysis() {
-        env::remove_var("GITHUB_OUTPUT"); // avoid writing to GH_OUT in parallel-running tests
+        monkey_patch_gh_output();
         let result = run_main(vec![
             "cpp-linter".to_string(),
             "-l".to_string(),

--- a/cpp-linter/tests/comments.rs
+++ b/cpp-linter/tests/comments.rs
@@ -66,7 +66,6 @@ async fn setup(lib_root: &Path, test_params: &TestParams) {
         "GITHUB_EVENT_NAME",
         test_params.event_t.to_string().as_str(),
     );
-    env::remove_var("GITHUB_OUTPUT"); // avoid writing to GH_OUT in parallel-running tests
     env::set_var("GITHUB_REPOSITORY", REPO);
     env::set_var("GITHUB_SHA", SHA);
     env::set_var("GITHUB_TOKEN", TOKEN);
@@ -251,6 +250,8 @@ async fn test_comment(test_params: &TestParams) {
     let tmp_dir = create_test_space(true);
     let lib_root = env::current_dir().unwrap();
     env::set_current_dir(tmp_dir.path()).unwrap();
+    let fake_gh_out = NamedTempFile::new().unwrap();
+    env::set_var("GITHUB_OUTPUT", fake_gh_out.path());
     setup(&lib_root, test_params).await;
     env::set_current_dir(lib_root.as_path()).unwrap();
     drop(tmp_dir);

--- a/cpp-linter/tests/reviews.rs
+++ b/cpp-linter/tests/reviews.rs
@@ -72,7 +72,6 @@ fn generate_tool_summary(review_enabled: bool, force_lgtm: bool, tool_name: &str
 }
 
 async fn setup(lib_root: &Path, test_params: &TestParams) {
-    env::remove_var("GITHUB_OUTPUT"); // avoid writing to GH_OUT in parallel-running tests
     env::set_var("GITHUB_EVENT_NAME", "pull_request");
     env::set_var("GITHUB_REPOSITORY", REPO);
     env::set_var("GITHUB_SHA", SHA);
@@ -247,6 +246,8 @@ async fn setup(lib_root: &Path, test_params: &TestParams) {
 async fn test_review(test_params: &TestParams) {
     let tmp_dir = create_test_space(true);
     let lib_root = env::current_dir().unwrap();
+    let fake_gh_out = NamedTempFile::new().unwrap();
+    env::set_var("GITHUB_OUTPUT", fake_gh_out.path());
     env::set_current_dir(tmp_dir.path()).unwrap();
     setup(&lib_root, test_params).await;
     env::set_current_dir(lib_root.as_path()).unwrap();


### PR DESCRIPTION
I'm guessing that the parallel writes to `GITHUB_OUTPUT` env var are causing the test CI to behave as if the workflow never finishes.

This patch, hopefully, should fix that by changing the env var's value to a temp file created during the test.

This also includes new clippy fixes using stable rust v1.87.