### PR TITLE
refactor: use `Client` instance by reference

### DIFF
--- a/cpp-linter/src/common_fs/file_filter.rs
+++ b/cpp-linter/src/common_fs/file_filter.rs
@@ -61,7 +61,8 @@ impl FileFilter {
             for line in read_buf.split('\n') {
                 if line.trim_start().starts_with("path") {
                     assert!(line.find('=').unwrap() > 0);
-                    let submodule = String::from("./") + line.split('=').last().unwrap().trim();
+                    let submodule =
+                        String::from("./") + line.split('=').next_back().unwrap().trim();
                     log::debug!("Found submodule: {submodule}");
                     let mut is_ignored = true;
                     for pat in &self.not_ignored {
@@ -159,7 +160,7 @@ impl FileFilter {
                 let mut is_hidden = false;
                 let parent = path
                     .components()
-                    .last()
+                    .next_back()
                     .ok_or(anyhow!("parent directory not known for {path:?}"))?;
                 if parent.as_os_str().to_str().unwrap().starts_with('.') {
                     is_hidden = true;

--- a/cpp-linter/src/rest_api/github/mod.rs
+++ b/cpp-linter/src/rest_api/github/mod.rs
@@ -16,7 +16,7 @@ use reqwest::{
 };
 
 // project specific modules/crates
-use super::{RestApiClient, RestApiRateLimitHeaders};
+use super::{send_api_request, RestApiClient, RestApiRateLimitHeaders};
 use crate::clang_tools::clang_format::tally_format_advice;
 use crate::clang_tools::clang_tidy::tally_tidy_advice;
 use crate::clang_tools::ClangVersions;
@@ -148,14 +148,9 @@ impl RestApiClient for GithubApiClient {
                 None,
                 Some(diff_header),
             )?;
-            let response = Self::send_api_request(
-                self.client.clone(),
-                request,
-                self.rate_limit_headers.to_owned(),
-                0,
-            )
-            .await
-            .with_context(|| "Failed to get list of changed files.")?;
+            let response = send_api_request(&self.client, request, &self.rate_limit_headers)
+                .await
+                .with_context(|| "Failed to get list of changed files.")?;
             if response.status().is_success() {
                 Ok(parse_diff_from_buf(
                     &response.bytes().await?,


### PR DESCRIPTION
This moves async fn out of trait declaration to allow using `Client` instance passed by reference.

This avoids cloning the `Client` instance which consequently created a new connection to the same domain.