### PR TITLE
feat: distribute future-compatible python wheels

### DIFF
--- a/.github/workflows/python-packaging.yml
+++ b/.github/workflows/python-packaging.yml
@@ -183,12 +183,14 @@ jobs:
           pattern: wheels-*
           path: dist
           merge-multiple: true
-      - name: Install uv
+      - name: Setup Python
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        uses: astral-sh/setup-uv@v6
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
       - name: Check distributions
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: uvx twine check dist/*
+        run: pipx run twine check dist/*
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 bench = false
 
 [dependencies]
-pyo3 = { version = "0.26.0", features = ["extension-module"] }
+pyo3 = { version = "0.26.0", features = ["extension-module", "abi3-py39"] }
 cpp-linter = { path = "../../cpp-linter" }
 tokio = "1.47.1"
 

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -70,6 +70,7 @@ words:
   - patchelf
   - peaceiris
   - peekable
+  - pipx
   - pkgs
   - posargs
   - positionals


### PR DESCRIPTION
resolves #177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build updated to produce ABI3-compatible Python wheels (broader Python 3.x compatibility; no runtime changes).
  * Release workflow updated to use the maintained Python setup action, improved publishing logic (test vs. main registry), and more robust distribution checks.

* **Style**
  * Spellchecker dictionary expanded to recognize "pipx".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->