### PR TITLE
style: start phasing out `.unwrap()` calls

### DIFF
--- a/cpp-linter/clippy.toml
+++ b/cpp-linter/clippy.toml
@@ -1,0 +1,1 @@
+allow-unwrap-in-tests = true

--- a/cpp-linter/src/cli/mod.rs
+++ b/cpp-linter/src/cli/mod.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::unwrap_used)]
+
 //! This module holds the Command Line Interface design.
 use std::{path::PathBuf, str::FromStr};
 
@@ -437,17 +439,17 @@ pub struct FeedbackOptions {
 /// the value will be split at spaces.
 pub fn convert_extra_arg_val(args: &[String]) -> Vec<String> {
     let mut val = args.iter();
-    if val.len() == 1 {
+    if args.len() == 1
+        && let Some(v) = val.next()
+    {
         // specified once; split and return result
-        val.next()
-            .unwrap()
-            .trim_matches('\'')
+        v.trim_matches('\'')
             .trim_matches('"')
             .split(' ')
             .map(|i| i.to_string())
             .collect()
     } else {
-        // specified multiple times; just return
+        // specified multiple times; just return a clone of the values
         val.map(|i| i.to_string()).collect()
     }
 }

--- a/cpp-linter/src/logger.rs
+++ b/cpp-linter/src/logger.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::unwrap_used)]
 //! A module to initialize and customize the logger object used in (most) stdout.
 
 use std::{
@@ -36,7 +37,7 @@ impl Log for SimpleLogger {
             writeln!(stdout, "{}", record.args()).expect("Failed to write log command to stdout");
             stdout
                 .flush()
-                .expect("Failed to flush log command to stdout");
+                .expect("Failed to flush log command in stdout");
         } else if self.enabled(record.metadata()) {
             let module = record.module_path();
             if module.is_none_or(|v| v.starts_with("cpp_linter")) {
@@ -47,12 +48,12 @@ impl Log for SimpleLogger {
                     record.args()
                 )
                 .expect("Failed to write log message to stdout");
-            } else {
+            } else if let Some(module) = module {
                 writeln!(
                     stdout,
                     "[{}]{{{}:{}}}: {}",
                     Self::level_color(&record.level()),
-                    module.unwrap(), // safe to unwrap here because the None case is caught above
+                    module,
                     record.line().unwrap_or_default(),
                     record.args()
                 )
@@ -60,7 +61,7 @@ impl Log for SimpleLogger {
             }
             stdout
                 .flush()
-                .expect("Failed to flush log message to stdout");
+                .expect("Failed to flush log message in stdout");
         }
     }
 

--- a/cpp-linter/src/main.rs
+++ b/cpp-linter/src/main.rs
@@ -1,4 +1,5 @@
 #![cfg(not(test))]
+#![deny(clippy::unwrap_used)]
 /// This crate is the binary executable's entrypoint.
 use std::env;
 

--- a/cpp-linter/src/rest_api/github/mod.rs
+++ b/cpp-linter/src/rest_api/github/mod.rs
@@ -184,8 +184,8 @@ impl RestApiClient for GithubApiClient {
         feedback_inputs: FeedbackInput,
         clang_versions: ClangVersions,
     ) -> Result<u64> {
-        let tidy_checks_failed = tally_tidy_advice(files);
-        let format_checks_failed = tally_format_advice(files);
+        let tidy_checks_failed = tally_tidy_advice(files)?;
+        let format_checks_failed = tally_format_advice(files)?;
         let mut comment = None;
 
         if feedback_inputs.file_annotations {

--- a/cpp-linter/src/run.rs
+++ b/cpp-linter/src/run.rs
@@ -2,7 +2,7 @@
 //!
 //! In python, this module is exposed as `cpp_linter.run` that has 1 function exposed:
 //! `main()`.
-
+#![deny(clippy::unwrap_used)]
 use std::{
     env,
     path::Path,


### PR DESCRIPTION
Any `.unwrap()` will cause a panic from the call site. This replaces some calls to `.unwrap()` with a proper error message that can be better understood by users.

Most of these calls sites are guarded by if conditions, so these new error messages should never be seen.
But, just in case there's is some unforeseen bad behavior, these error messages should provide a better user experience.

This doesn't cover the all of cpp-linter/**.rs sources. I've started migrating some of the REST API and git diff-ing behavior to [2bndy5/git-bot-feedback]. In doing so, the `.unwrap()` calls were replaced with custom exceptions. So, migrating to [2bndy5/git-bot-feedback] should take care of most other `.unwrap()` calls.

[2bndy5/git-bot-feedback]: https://github.com/2bndy5/git-bot-feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust error handling for formatting and linting tools with clearer diagnostics and safer path resolution.
  * Safer file processing and recovery during analysis to avoid unexpected panics.

* **Refactor**
  * Consolidated suggestion construction and improved logging for clearer, deduplicated review comments.
  * Replaced unsafe unwraps with explicit error handling across the codebase.

* **Chores**
  * Adjusted lint rules to allow test-only unwraps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->