### PR TITLE
feat: allow specifying the base commit for local (non-CI) diffs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@ nextest-version = "0.9.77"
 
 [profile.default]
 # A profile to run most tests, except tests that run longer than 10 seconds
-default-filter = "not test(#*rate_limit_secondary) - test(#git::test::with_*)"
+default-filter = "not test(#*rate_limit_secondary) - test(#git::test::with_*) - test(#repo_get_sha)"
 
 # This will flag any test that runs longer than 10 seconds. Useful when writing new tests.
 slow-timeout = "10s"

--- a/cpp-linter/src/cli/mod.rs
+++ b/cpp-linter/src/cli/mod.rs
@@ -199,7 +199,7 @@ pub struct SourceOptions {
     /// The git reference to use as the base for diffing changed files.
     ///
     /// This can be any valid git ref, such as a branch name, tag name, or commit SHA.
-    /// If it in integer, then it is treated as the number of parent commits from HEAD.
+    /// If it is an integer, then it is treated as the number of parent commits from HEAD.
     ///
     /// This option only applies to non-CI contexts (eg. local CLI use).
     #[arg(

--- a/cpp-linter/src/cli/mod.rs
+++ b/cpp-linter/src/cli/mod.rs
@@ -195,6 +195,27 @@ pub struct SourceOptions {
         verbatim_doc_comment
     )]
     pub ignore: Vec<String>,
+
+    /// The git reference to use as the base for diffing changed files.
+    ///
+    /// This can be any valid git ref, such as a branch name, tag name, or commit SHA.
+    /// If it in integer, then it is treated as the number of parent commits from HEAD.
+    ///
+    /// This option only applies to non-CI contexts (eg. local CLI use).
+    #[arg(
+        short = 'b',
+        long,
+        value_name = "REF",
+        help_heading = "Source options",
+        verbatim_doc_comment
+    )]
+    pub diff_base: Option<String>,
+
+    /// Assert this switch to ignore any staged changes when
+    /// generating a diff of changed files.
+    /// Useful when used with [`--diff-base`](#-b-diff-base).
+    #[arg(default_value_t = false, long, help_heading = "Source options")]
+    pub ignore_index: bool,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/cpp-linter/src/git.rs
+++ b/cpp-linter/src/git.rs
@@ -40,7 +40,7 @@ fn get_sha<'d, T: Display>(
     match depth {
         Some(base) => {
             let base = base.to_string();
-            if base.chars().all(|c| c.is_digit(10)) {
+            if base.chars().all(|c| c.is_ascii_digit()) {
                 repo.revparse_single(format!("HEAD~{}", base).as_str())
             } else {
                 repo.revparse_single(base.as_str())
@@ -90,7 +90,7 @@ pub fn get_diff<'d, T: Display>(
     let base = if diff_base.is_some() {
         // diff base is specified (regardless of staged changes)
         get_sha(repo, diff_base)
-    } else if !use_staged_files && !ignore_index {
+    } else if !use_staged_files {
         // diff base is unspecified, when the repo has
         // no staged changes (and they are not ignored),
         // then focus on just the last commit

--- a/cpp-linter/src/git.rs
+++ b/cpp-linter/src/git.rs
@@ -39,10 +39,11 @@ fn get_sha<'d, T: Display>(
 ) -> Result<git2::Object<'d>, Error> {
     match depth {
         Some(base) => {
-            if base.to_string().parse::<u32>().is_ok() {
+            let base = base.to_string();
+            if base.chars().all(|c| c.is_digit(10)) {
                 repo.revparse_single(format!("HEAD~{}", base).as_str())
             } else {
-                repo.revparse_single(format!("{base}").as_str())
+                repo.revparse_single(base.as_str())
             }
         }
         None => repo.revparse_single("HEAD"),

--- a/cpp-linter/src/git.rs
+++ b/cpp-linter/src/git.rs
@@ -610,6 +610,8 @@ mod test {
             let their_obj = get_sha(&repo, &Some(theirs)).unwrap();
             assert_eq!(our_obj.id(), their_obj.id());
         }
+        // test an invalid ref for coverage measurement
+        assert!(get_sha(&repo, &Some("1.0")).is_err());
         drop(tmp_dir); // delete temp_folder
     }
 }

--- a/cpp-linter/src/run.rs
+++ b/cpp-linter/src/run.rs
@@ -104,14 +104,24 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
     {
         // parse_diff(github_rest_api_payload)
         rest_api_client
-            .get_list_of_changed_files(&file_filter, &cli.source_options.lines_changed_only)
+            .get_list_of_changed_files(
+                &file_filter,
+                &cli.source_options.lines_changed_only,
+                &cli.source_options.diff_base,
+                cli.source_options.ignore_index,
+            )
             .await?
     } else {
         // walk the folder and look for files with specified extensions according to ignore values.
         let mut all_files = file_filter.list_source_files(".")?;
         if is_pr && (cli.feedback_options.tidy_review || cli.feedback_options.format_review) {
             let changed_files = rest_api_client
-                .get_list_of_changed_files(&file_filter, &LinesChangedOnly::Off)
+                .get_list_of_changed_files(
+                    &file_filter,
+                    &LinesChangedOnly::Off,
+                    &cli.source_options.diff_base,
+                    cli.source_options.ignore_index,
+                )
                 .await?;
             for changed_file in changed_files {
                 for file in &mut all_files {

--- a/cpp-linter/tests/paginated_changed_files.rs
+++ b/cpp-linter/tests/paginated_changed_files.rs
@@ -144,7 +144,7 @@ async fn get_paginated_changes(lib_root: &Path, test_params: &TestParams) {
 
     let file_filter = FileFilter::new(&[], vec!["cpp".to_string(), "hpp".to_string()]);
     let files = client
-        .get_list_of_changed_files(&file_filter, &LinesChangedOnly::Off)
+        .get_list_of_changed_files(&file_filter, &LinesChangedOnly::Off, &None::<u8>, false)
         .await;
     match files {
         Err(e) => {

--- a/docs/cli.yml
+++ b/docs/cli.yml
@@ -49,6 +49,10 @@ inputs:
     required-permission: 'pull-requests: write #pull-request-reviews'
   jobs:
     minimum-version: '1.8.1'
+  diff-base:
+    minimum-version: '1.12.0'
+  ignore-index:
+    minimum-version: '1.12.0'
 outputs:
   checks-failed:
     minimum-version: '1.4.6'

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -84,17 +84,11 @@ fn generate_cli_doc(metadata: HashMap<String, HashMap<String, Py<PyAny>>>) -> Py
                 "Failed to get long name of argument with id {}",
                 arg_id.as_str()
             )))?;
-            out.push_str(
-                format!(
-                    "\n### `-{}, --{}`\n\n",
-                    arg.get_short().ok_or(PyValueError::new_err(format!(
-                        "Failed to get short name for argument with id {}",
-                        arg_id.as_str()
-                    )))?,
-                    long_name
-                )
-                .as_str(),
-            );
+            let short_name = arg
+                .get_short()
+                .map(|c| format!("-{}, ", c))
+                .unwrap_or_default();
+            out.push_str(format!("\n### `{}--{}`\n\n", short_name, long_name).as_str());
             if let Some(map) = metadata.get(long_name) {
                 if let Some(val) = map.get("minimum-version") {
                     out.push_str(format!("<!-- md:version {} -->\n", val).as_str());


### PR DESCRIPTION
- ref cpp-linter/cpp-linter#180
- as discussed in cpp-linter/cpp-linter#179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --diff-base and --ignore-index CLI options to control base diffs and staged-file handling.

* **Documentation**
  * Documented new CLI options (minimum version 1.12.0).
  * Improved CLI argument header formatting to handle missing short names.

* **Chores**
  * Default test filter updated to exclude a specific test.

* **Tests**
  * Tests expanded to cover diff-base and ignore-index behaviors and updated call sites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->