### PR TITLE
fix: restore cargo binstall support

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -153,12 +153,12 @@ jobs:
           $tgt = "cpp-linter"
           mv "../target/${{ matrix.target }}/release/${tgt}.exe" "./${tgt}.exe"
           $arc_name = "${tgt}-${{ matrix.target }}.zip"
-          tar -a -c -v -f "${arc_name}" ${tgt}.exe LICENSE
+          tar -a -c -v -f "${arc_name}" "${tgt}.exe" "LICENSE"
 
           $tgt = "clang-tools"
           mv "../target/${{ matrix.target }}/release/${tgt}.exe" "./${tgt}.exe"
           $arc_name = "${tgt}-${{ matrix.target }}.zip"
-          tar -a -c -v -f "${arc_name}" ${tgt}.exe LICENSE
+          tar -a -c -v -f "${arc_name}" "${tgt}.exe" "LICENSE"
       - name: Upload cpp-linter artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/bump-n-release.yml
+++ b/.github/workflows/bump-n-release.yml
@@ -32,11 +32,16 @@ on:
           - patch
           - rc
 
+run-name: >-
+  ${{ inputs.package && 'Deploy ' || 'Show Unreleased Changes' }}
+  ${{ inputs.package || '' }}
+
 permissions: {}
 
 jobs:
   bump-release:
     if: github.event_name == 'workflow_dispatch'
+    name: Bump ${{ inputs.component }} version of ${{ inputs.package }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@
 
 # C/C++ Linting Package
 
-A package for linting C/C++ code with clang-tidy and/or clang-format to collect feedback provided in the form of
+A package for linting C/C++ code with clang-tidy and/or clang-format to collect
+feedback provided in the form of
 
 - [x] [thread-comments](#thread-comment)
 - [x] [step-summary](#step-summary)
@@ -67,7 +68,8 @@ A package for linting C/C++ code with clang-tidy and/or clang-format to collect 
 
 ## Install
 
-This package is available in several programming languages (through their respective package managers).
+This package is available in several programming languages (through their
+respective package managers).
 
 ### Rust
 
@@ -77,7 +79,7 @@ This package is available in several programming languages (through their respec
 Install from source code hosted at crates.io:
 
 ```text
-cargo install cpp-linter
+cargo install cpp-linter --features bin
 ```
 
 Install a pre-compiled binary from GitHub releases:
@@ -175,6 +177,7 @@ To provide feedback (requesting a feature or reporting a bug) please post to
 
 The scripts and documentation in this project are released under the [MIT] license.
 
-As for dependencies (that are redistributed by us in binary form) and their licenses, refer to [THIRD-PARTY LICENSES][other-licenses].
+As for dependencies (that are redistributed by us in binary form) and their
+licenses, refer to [THIRD-PARTY LICENSES][other-licenses].
 
 [MIT]: https://choosealicense.com/licenses/mit

--- a/clang-installer/Cargo.toml
+++ b/clang-installer/Cargo.toml
@@ -45,11 +45,7 @@ reqwest = { workspace = true, features = ["default-tls"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]
-bin = ["clap", "tokio", "anyhow", "colored"]
-clap = ["dep:clap"]
-tokio = ["dep:tokio"]
-anyhow = ["dep:anyhow"]
-colored = ["dep:colored"]
+bin = ["dep:clap", "dep:tokio", "dep:anyhow", "dep:colored"]
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/{ name }/v{ version }/{ bin }-{ target }{ archive-suffix }"
+pkg-url = "{ repo }/releases/download/clang-installer/v{ version }/{ name }-{ target }{ archive-suffix }"

--- a/clang-installer/src/tool.rs
+++ b/clang-installer/src/tool.rs
@@ -54,7 +54,7 @@ pub enum GetClangVersionError {
 
 /// A enumeration of supported clang tools.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "bin", derive(clap::ValueEnum))]
 pub enum ClangTool {
     ClangTidy,
     ClangFormat,

--- a/cpp-linter/Cargo.toml
+++ b/cpp-linter/Cargo.toml
@@ -59,4 +59,4 @@ bench = false
 required-features = ["bin"]
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/{ name }/v{ version }/{ bin }-{ target }{ archive-suffix }"
+pkg-url = "{ repo }/releases/download/cpp-linter/v{ version }/{ name }-{ target }{ archive-suffix }"


### PR DESCRIPTION
- adjust suggested install command in README
- ensure the binary executables are included in release assets (affected windows only)
- adjust the custom `pkg-url` in Cargo.toml metadata for this monorepo's tag prefixes

I also changed the features of clang-installer since they were all related to the conditional bin feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with revised installation instructions, including new guidance for Rust package installation.

* **Chores**
  * Enhanced Windows artifact packaging process.
  * Refined build configuration and feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->