### PR TITLE
docs: revise third-party license tables in docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "git-bot-feedback"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002bc7450062bd6651a86e99a454f52aea873bfe293d24cfabbf52180c97da89"
+checksum = "2188a95438d5b5a329cd55f422c88cdc6efd8a191f88e1167270bb2ff8bcaee3"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cpp-linter/Cargo.toml
+++ b/cpp-linter/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [dependencies.git-bot-feedback]
-version = "0.5.4"
+version = "0.5.5"
 features = ["file-changes"]
 # path = "../../git-bot-feedback"
 # git = "https://github.com/2bndy5/git-bot-feedback"

--- a/docs/license_gen.py
+++ b/docs/license_gen.py
@@ -9,6 +9,7 @@ INTRO = """# Third-party Licenses
 [MIT]: https://choosealicense.com/licenses/mit
 [Apache-2.0]: https://choosealicense.com/licenses/apache-2.0/
 [MPL-2.0]: https://choosealicense.com/licenses/mpl-2.0
+[GPL-3.0]: https://choosealicense.com/licenses/gpl-3.0/
 """
 
 TABLE_HEADER = "| Dependency | License |\n|:------------|:-------|\n"
@@ -23,17 +24,6 @@ CLANG_INSTALLER_DEPS = f"""## clang-installer's dependencies
 {TABLE_HEADER}\
 """
 
-OPTIONAL_DEPS = f"""## Optional dependencies
-
-The following are conditionally included in binaries (using the `openssl-vendored`
-feature on a case-by-case basis) because it is a dependency of
-[git2](https://crates.io/crates/git2):
-
-{TABLE_HEADER}\
-| [openssl](https://crates.io/crates/openssl) | [Apache-2.0] |
-| [openssl-probe](https://crates.io/crates/openssl-probe) | [MIT] OR [Apache-2.0] |
-"""
-
 PY_BINDING_HEADER = f"""## Bindings' dependencies
 
 ### Python binding
@@ -44,7 +34,9 @@ JS_BINDING_HEADER = f"""### Node.js binding
 
 {TABLE_HEADER}"""
 
-SELF_DEP = re.compile(r"(\| \[cpp-linter v[0-9.]+[^\s]*)[^\]]+(\]\(.*)$")
+SELF_DEP = re.compile(
+    r"(\| \[(?:cpp-linter|clang-installer) v[0-9.]+[^\s]*)[^\]]+(\]\(.*)$"
+)
 
 
 class TreeGetter:
@@ -80,6 +72,7 @@ class TreeGetter:
                 .replace(" MIT", " [MIT]")
                 .replace(" Apache-2.0", " [Apache-2.0]")
                 .replace(" MPL-2.0", " [MPL-2.0]")
+                .replace(" GPL-3.0", " [GPL-3.0]")
                 .strip()
             )
             self_match = SELF_DEP.match(dep)
@@ -96,7 +89,6 @@ with mkdocs_gen_files.open(FILENAME, "w") as io_doc:
     doc += tg.get_output()
     # print(doc)
     print(doc, file=io_doc)
-    print(f"\n{OPTIONAL_DEPS}\n", file=io_doc)
     tg.package("cpp-linter-py")
     doc = tg.get_output()
     print(f"\n{PY_BINDING_HEADER}{doc}", file=io_doc)


### PR DESCRIPTION
I had to bump git-bot-feedback so that its metadata uses a SPDX identifier (instead of a LICENSE file which is not a custom license).

I also removed the hard-coded table about OpenSSL now that we don't use it anymore.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest versions

* **Documentation**
  * Improved license documentation generation to include GPL-3.0 reference with proper link attribution
  * Simplified generated license documentation by removing optional dependencies section
  * Enhanced self-dependency detection for versioned package entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->