### PR TITLE
fix: show used clang tools' version in logs

### DIFF
--- a/cpp-linter/src/clang_tools/mod.rs
+++ b/cpp-linter/src/clang_tools/mod.rs
@@ -113,6 +113,12 @@ pub async fn capture_clang_tools_output(
         let tool_info = version.eval_tool(&tool, false, None).await?.ok_or(anyhow!(
             "Failed to find {tool} or install a suitable version"
         ))?;
+        log::info!(
+            "Using {tool} version {}.{}.{}",
+            tool_info.version.major,
+            tool_info.version.minor,
+            tool_info.version.patch,
+        );
         clang_versions.tidy_version = Some(tool_info.version);
         clang_params.clang_tidy_command = Some(tool_info.path);
     }
@@ -121,6 +127,12 @@ pub async fn capture_clang_tools_output(
         let tool_info = version.eval_tool(&tool, false, None).await?.ok_or(anyhow!(
             "Failed to find {tool} or install a suitable version"
         ))?;
+        log::info!(
+            "Using {tool} version {}.{}.{}",
+            tool_info.version.major,
+            tool_info.version.minor,
+            tool_info.version.patch,
+        );
         clang_versions.format_version = Some(tool_info.version);
         clang_params.clang_format_command = Some(tool_info.path);
     }


### PR DESCRIPTION
resolves #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit version logging for clang-tidy and clang-format tools. Users can now see which specific versions of these tools are being used during linting and formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->