### PR TITLE
feat: make diff without libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,7 +387,7 @@ dependencies = [
  "fast-glob",
  "futures",
  "git-bot-feedback",
- "git2",
+ "gix-imara-diff",
  "log",
  "mockito",
  "quick-xml",
@@ -564,6 +573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,15 +751,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.21.0"
+name = "gix-imara-diff"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
 dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
+ "bstr",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -772,7 +785,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -780,6 +793,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1141,18 +1157,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.5+1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005d6ae6eac1912906073e069f7db60b1fa98e052a68227824afe3e3a1c59ca2"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,18 +1173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -1405,12 +1397,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -2335,12 +2321,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/cpp-linter/Cargo.toml
+++ b/cpp-linter/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true, optional = true }
 colored = { workspace = true, optional = true }
 fast-glob = "1.0.1"
 futures = "0.3.32"
-git2 = { version = "0.21.0" }
+gix-imara-diff = { version = "0.2.2", features = ["unified_diff"] }
 log = { workspace = true }
 quick-xml = { version = "0.40.1", features = ["serialize"] }
 regex = { workspace = true }

--- a/cpp-linter/src/clang_tools/mod.rs
+++ b/cpp-linter/src/clang_tools/mod.rs
@@ -11,9 +11,7 @@ use std::{
 // non-std crates
 use clang_tools_manager::{ClangTool, RequestedVersion};
 use git_bot_feedback::ReviewComment;
-use gix_imara_diff::{
-    BasicLineDiffPrinter, Diff, InternedInput, UnifiedDiffConfig, UnifiedDiffPrinter,
-};
+use gix_imara_diff::{BasicLineDiffPrinter, Diff, InternedInput, UnifiedDiffConfig};
 use semver::Version;
 use tokio::task::JoinSet;
 
@@ -360,17 +358,13 @@ pub trait MakeSuggestions {
                         );
                     } else {
                         suggestion.push_str("```suggestion\n");
-                        printer
-                            .display_hunk(
-                                &mut suggestion,
-                                &input.before[hunk.before.start as usize..hunk.before.end as usize],
-                                &input.after[hunk.after.start as usize..hunk.after.end as usize],
-                            )
-                            .map_err(|e| SuggestionError::HunkIntoStringFailed {
-                                file_name: file_name.clone(),
-                                source: e,
-                            })?;
-                        suggestion.push_str("```");
+                        for token in
+                            &input.after[hunk.after.start as usize..hunk.after.end as usize]
+                        {
+                            let line = &input.interner[*token];
+                            suggestion.push_str(line);
+                        }
+                        suggestion.push_str("```\n");
                     }
                     let comment = Suggestion {
                         line_start: start_line,
@@ -384,8 +378,8 @@ pub trait MakeSuggestions {
                 }
             }
         }
-        review_comments.tool_total[is_tidy_tool] =
-            Some(review_comments.tool_total[is_tidy_tool].unwrap_or_default() + hunks_in_patch);
+        let tool_total = review_comments.tool_total[is_tidy_tool].get_or_insert(0);
+        *tool_total += hunks_in_patch;
         Ok(())
     }
 }

--- a/cpp-linter/src/clang_tools/mod.rs
+++ b/cpp-linter/src/clang_tools/mod.rs
@@ -4,14 +4,16 @@
 
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, Mutex},
 };
 
 // non-std crates
 use clang_tools_manager::{ClangTool, RequestedVersion};
 use git_bot_feedback::ReviewComment;
-use git2::{DiffOptions, Patch};
+use gix_imara_diff::{
+    BasicLineDiffPrinter, Diff, InternedInput, UnifiedDiffConfig, UnifiedDiffPrinter,
+};
 use semver::Version;
 use tokio::task::JoinSet;
 
@@ -291,20 +293,13 @@ impl ReviewComments {
 }
 
 pub fn make_patch<'buffer>(
-    path: &Path,
-    patched: &'buffer [u8],
-    original_content: &'buffer [u8],
-) -> Result<Patch<'buffer>, git2::Error> {
-    let mut diff_opts = &mut DiffOptions::new();
-    diff_opts = diff_opts.indent_heuristic(true);
-    diff_opts = diff_opts.context_lines(0);
-    Patch::from_buffers(
-        original_content,
-        Some(path),
-        patched,
-        Some(path),
-        Some(diff_opts),
-    )
+    patched: &'buffer str,
+    original_content: &'buffer str,
+) -> (Diff, InternedInput<&'buffer str>) {
+    let input = InternedInput::new(original_content, patched);
+    let mut diff = Diff::compute(gix_imara_diff::Algorithm::Histogram, &input);
+    diff.postprocess_lines(&input);
+    (diff, input)
 }
 
 /// A trait for generating suggestions from a [`FileObj`]'s advice's generated `patched` buffer.
@@ -320,46 +315,31 @@ pub trait MakeSuggestions {
         &self,
         review_comments: &mut ReviewComments,
         file_obj: &FileObj,
-        patch: &mut Patch,
+        diff: &Diff,
+        input: &InternedInput<&str>,
         summary_only: bool,
     ) -> Result<(), SuggestionError> {
         let is_tidy_tool = (&self.get_tool_name() == "clang-tidy") as usize;
-        let hunks_total = patch.num_hunks();
-        let mut hunks_in_patch = 0u32;
         let file_name = file_obj
             .name
             .to_string_lossy()
             .replace("\\", "/")
             .trim_start_matches("./")
             .to_owned();
-        let patch_buf = &patch
-            .to_buf()
-            .map_err(|e| SuggestionError::PatchIntoBytesFailed {
-                file_name: file_name.clone(),
-                source: e,
-            })?
-            .to_vec();
-        review_comments.full_patch[is_tidy_tool].push_str(
-            String::from_utf8(patch_buf.to_owned())
-                .map_err(|e| SuggestionError::PatchIntoStringFailed {
-                    file_name: file_name.clone(),
-                    source: e,
-                })?
-                .as_str(),
-        );
+        let mut config = UnifiedDiffConfig::default();
+        config.context_len(0);
+        let printer = BasicLineDiffPrinter(&input.interner);
+        let unified_diff = diff.unified_diff(&printer, config, input).to_string();
+        if !unified_diff.is_empty() {
+            let patch_buf = format!("--- a/{file_name}\n+++ b/{file_name}\n{unified_diff}");
+            review_comments.full_patch[is_tidy_tool].push_str(patch_buf.as_str());
+        }
         if summary_only {
             review_comments.tool_total[is_tidy_tool].get_or_insert(0);
             return Ok(());
         }
-        for hunk_id in 0..hunks_total {
-            let (hunk, line_count) =
-                patch
-                    .hunk(hunk_id)
-                    .map_err(|e| SuggestionError::GetHunkFailed {
-                        hunk_id,
-                        file_name: file_name.clone(),
-                        source: e,
-                    })?;
+        let mut hunks_in_patch = 0u32;
+        for hunk in diff.hunks() {
             hunks_in_patch += 1;
             let hunk_range = file_obj.is_hunk_in_diff(&hunk);
             match hunk_range {
@@ -367,49 +347,30 @@ pub trait MakeSuggestions {
                 Some((start_line, end_line)) => {
                     let mut suggestion = String::new();
                     let suggestion_help = self.get_suggestion_help(start_line, end_line);
-                    let mut removed = vec![];
-                    for line_index in 0..line_count {
-                        let diff_line = patch.line_in_hunk(hunk_id, line_index).map_err(|e| {
-                            SuggestionError::GetHunkLineFailed {
-                                line_index,
-                                hunk_id,
-                                file_name: file_name.clone(),
-                                source: e,
-                            }
-                        })?;
-                        let line =
-                            String::from_utf8(diff_line.content().to_owned()).map_err(|e| {
-                                SuggestionError::HunkLineIntoStringFailed {
-                                    line_index,
-                                    hunk_id,
-                                    file_name: file_name.clone(),
-                                    source: e,
-                                }
-                            })?;
-                        if ['+', ' '].contains(&diff_line.origin()) {
-                            suggestion.push_str(line.as_str());
-                        } else {
-                            removed.push(
-                                diff_line
-                                    .old_lineno()
-                                    .expect("Removed line should have a line number"),
-                            );
-                        }
-                    }
-                    if suggestion.is_empty() && !removed.is_empty() {
+                    if hunk.is_pure_removal() {
                         suggestion.push_str(
                             format!(
                                 "Please remove the line(s)\n- {}",
-                                removed
-                                    .iter()
+                                hunk.before
                                     .map(|l| l.to_string())
                                     .collect::<Vec<String>>()
                                     .join("\n- ")
                             )
                             .as_str(),
-                        )
+                        );
                     } else {
-                        suggestion = format!("```suggestion\n{suggestion}```");
+                        suggestion.push_str("```suggestion\n");
+                        printer
+                            .display_hunk(
+                                &mut suggestion,
+                                &input.before[hunk.before.start as usize..hunk.before.end as usize],
+                                &input.after[hunk.after.start as usize..hunk.after.end as usize],
+                            )
+                            .map_err(|e| SuggestionError::HunkIntoStringFailed {
+                                file_name: file_name.clone(),
+                                source: e,
+                            })?;
+                        suggestion.push_str("```");
                     }
                     let comment = Suggestion {
                         line_start: start_line,

--- a/cpp-linter/src/clang_tools/mod.rs
+++ b/cpp-linter/src/clang_tools/mod.rs
@@ -17,7 +17,7 @@ use tokio::task::JoinSet;
 
 // project-specific modules/crates
 use super::common_fs::FileObj;
-use crate::error::{ClangCaptureError, ClangTaskError, SuggestionError};
+use crate::error::{ClangCaptureError, ClangTaskError};
 use crate::{
     cli::ClangParams,
     rest_client::{RestClient, USER_OUTREACH},
@@ -316,7 +316,7 @@ pub trait MakeSuggestions {
         diff: &Diff,
         input: &InternedInput<&str>,
         summary_only: bool,
-    ) -> Result<(), SuggestionError> {
+    ) {
         let is_tidy_tool = (&self.get_tool_name() == "clang-tidy") as usize;
         let file_name = file_obj
             .name
@@ -334,7 +334,7 @@ pub trait MakeSuggestions {
         }
         if summary_only {
             review_comments.tool_total[is_tidy_tool].get_or_insert(0);
-            return Ok(());
+            return;
         }
         let mut hunks_in_patch = 0u32;
         for hunk in diff.hunks() {
@@ -380,6 +380,5 @@ pub trait MakeSuggestions {
         }
         let tool_total = review_comments.tool_total[is_tidy_tool].get_or_insert(0);
         *tool_total += hunks_in_patch;
-        Ok(())
     }
 }

--- a/cpp-linter/src/common_fs/mod.rs
+++ b/cpp-linter/src/common_fs/mod.rs
@@ -149,7 +149,7 @@ impl FileObj {
             let patched = String::from_utf8(patched.to_vec())
                 .map_err(|e| FileObjError::FromUtf8Error(file_name.clone(), e))?;
             let (diff, input) = make_patch(patched.as_str(), &original_content);
-            advice.get_suggestions(review_comments, self, &diff, &input, summary_only)?;
+            advice.get_suggestions(review_comments, self, &diff, &input, summary_only);
         }
 
         if let Some(advice) = &self.tidy_advice {
@@ -157,7 +157,7 @@ impl FileObj {
                 let patched = String::from_utf8(patched.to_vec())
                     .map_err(|e| FileObjError::FromUtf8Error(file_name.clone(), e))?;
                 let (diff, input) = make_patch(patched.as_str(), &original_content);
-                advice.get_suggestions(review_comments, self, &diff, &input, summary_only)?;
+                advice.get_suggestions(review_comments, self, &diff, &input, summary_only);
             }
 
             if summary_only {

--- a/cpp-linter/src/common_fs/mod.rs
+++ b/cpp-linter/src/common_fs/mod.rs
@@ -1,11 +1,8 @@
 //! A module to hold all common file system functionality.
 
-use std::{
-    fmt::Debug,
-    fs,
-    ops::RangeInclusive,
-    path::{Path, PathBuf},
-};
+use std::{fmt::Debug, fs, ops::RangeInclusive, path::PathBuf};
+
+use gix_imara_diff::Hunk;
 
 use crate::{
     clang_tools::{
@@ -15,7 +12,6 @@ use crate::{
     cli::LinesChangedOnly,
     error::FileObjError,
 };
-use git2::DiffHunk;
 
 /// A structure to represent a file's path and line changes.
 #[derive(Debug, Clone)]
@@ -101,14 +97,14 @@ impl FileObj {
 
     /// Is the range from `start_line` to `end_line` contained in a single item of
     /// [`FileObj::diff_chunks`]?
-    pub fn is_hunk_in_diff(&self, hunk: &DiffHunk) -> Option<(u32, u32)> {
-        let (start_line, end_line) = if hunk.old_lines() > 0 {
+    pub fn is_hunk_in_diff(&self, hunk: &Hunk) -> Option<(u32, u32)> {
+        let (start_line, end_line) = if !hunk.before.is_empty() {
             // if old hunk's total lines is > 0
-            let start = hunk.old_start();
-            (start, start + hunk.old_lines() - 1)
+            let start = hunk.before.start;
+            (start, start + hunk.before.len() as u32 - 1)
         } else {
             // old hunk's total lines is 0, meaning changes were only added
-            let start = hunk.new_start();
+            let start = hunk.after.start;
             // make old hunk's range span 1 line
             (start, start)
         };
@@ -145,22 +141,23 @@ impl FileObj {
         review_comments: &mut ReviewComments,
         summary_only: bool,
     ) -> Result<(), FileObjError> {
-        let original_content = fs::read(&self.name).map_err(FileObjError::ReadFile)?;
+        let original_content = fs::read_to_string(&self.name).map_err(FileObjError::ReadFile)?;
         let file_name = self.name.to_str().unwrap_or_default().replace("\\", "/");
-        let file_path = Path::new(&file_name);
         if let Some(advice) = &self.format_advice
             && let Some(patched) = &advice.patched
         {
-            let mut patch = make_patch(file_path, patched, &original_content)
-                .map_err(|e| FileObjError::MakePatchFailed(file_name.clone(), e))?;
-            advice.get_suggestions(review_comments, self, &mut patch, summary_only)?;
+            let patched = String::from_utf8(patched.to_vec())
+                .map_err(|e| FileObjError::FromUtf8Error(file_name.clone(), e))?;
+            let (diff, input) = make_patch(patched.as_str(), &original_content);
+            advice.get_suggestions(review_comments, self, &diff, &input, summary_only)?;
         }
 
         if let Some(advice) = &self.tidy_advice {
             if let Some(patched) = &advice.patched {
-                let mut patch = make_patch(file_path, patched, &original_content)
-                    .map_err(|e| FileObjError::MakePatchFailed(file_name.clone(), e))?;
-                advice.get_suggestions(review_comments, self, &mut patch, summary_only)?;
+                let patched = String::from_utf8(patched.to_vec())
+                    .map_err(|e| FileObjError::FromUtf8Error(file_name.clone(), e))?;
+                let (diff, input) = make_patch(patched.as_str(), &original_content);
+                advice.get_suggestions(review_comments, self, &diff, &input, summary_only)?;
             }
 
             if summary_only {

--- a/cpp-linter/src/error.rs
+++ b/cpp-linter/src/error.rs
@@ -2,23 +2,11 @@ use clang_tools_manager::GetToolError;
 use git_bot_feedback::RestClientError;
 
 #[derive(Debug, thiserror::Error)]
-pub enum SuggestionError {
-    #[error("Failed to write hunk of patch into string buffer for {file_name}: {source}")]
-    HunkIntoStringFailed {
-        file_name: String,
-        #[source]
-        source: core::fmt::Error,
-    },
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum FileObjError {
     #[error("Failed to read file contents")]
     ReadFile(std::io::Error),
     #[error("Failed to convert patch buffer to UTF-8 string for file {0}: {1}")]
     FromUtf8Error(String, #[source] std::string::FromUtf8Error),
-    #[error(transparent)]
-    SuggestionError(#[from] SuggestionError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/cpp-linter/src/error.rs
+++ b/cpp-linter/src/error.rs
@@ -3,44 +3,11 @@ use git_bot_feedback::RestClientError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SuggestionError {
-    #[error("Failed to convert patch for '{file_name}' into bytes: {source}")]
-    PatchIntoBytesFailed {
+    #[error("Failed to write hunk of patch into string buffer for {file_name}: {source}")]
+    HunkIntoStringFailed {
         file_name: String,
         #[source]
-        source: git2::Error,
-    },
-    #[error("Failed to convert patch for file '{file_name}' into string: {source}")]
-    PatchIntoStringFailed {
-        file_name: String,
-        #[source]
-        source: std::string::FromUtf8Error,
-    },
-    #[error("Failed to get hunk {hunk_id} from patch for {file_name}: {source}")]
-    GetHunkFailed {
-        hunk_id: usize,
-        file_name: String,
-        #[source]
-        source: git2::Error,
-    },
-    #[error(
-        "Failed to get line {line_index} in a hunk {hunk_id} of patch for {file_name}: {source}"
-    )]
-    GetHunkLineFailed {
-        line_index: usize,
-        hunk_id: usize,
-        file_name: String,
-        #[source]
-        source: git2::Error,
-    },
-    #[error(
-        "Failed to convert line {line_index} buffer to string in hunk {hunk_id} of patch for {file_name}: {source}"
-    )]
-    HunkLineIntoStringFailed {
-        line_index: usize,
-        hunk_id: usize,
-        file_name: String,
-        #[source]
-        source: std::string::FromUtf8Error,
+        source: core::fmt::Error,
     },
 }
 
@@ -48,8 +15,8 @@ pub enum SuggestionError {
 pub enum FileObjError {
     #[error("Failed to read file contents")]
     ReadFile(std::io::Error),
-    #[error("Failed to create patch for file {0:?}: {1}")]
-    MakePatchFailed(String, #[source] git2::Error),
+    #[error("Failed to convert patch buffer to UTF-8 string for file {0}: {1}")]
+    FromUtf8Error(String, #[source] std::string::FromUtf8Error),
     #[error(transparent)]
     SuggestionError(#[from] SuggestionError),
 }

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -43,7 +43,9 @@ words:
   - gnueabi
   - gnueabihf
   - hustcer
+  - imara
   - inlinehilite
+  - interner
   - iomanip
   - isnan
   - libc


### PR DESCRIPTION
resolves #303

This uses a pure-rust library called [imara-diff], which has been forked by the [gitoxide] project as a library named [gix-imara-diff]. I'm using the fork because the [imara-diff] lib has not been updated as recently as [gix-imara-diff]. Also, the [gix-imara-diff] is what is being used in the [gitoxide] project, so I think it is better maintained with a `git`-based focus in mind.

It boasts the same unified diff algorithms as used by `git` CLI. In fact, the [gitoxide] project is intended to be a rust implementation of git CLI and provides an API comparable to libgit2 (but with much more separation of concerns).

Creating and traversing a diff was the remaining use of libgit2 in our production code. Thus, libgit2 has been removed from our dependencies. However, the benchmark still uses libgit2 as the sample source files. Additionally, libgit2 had some memory safety concerns and because it is written in C, so [gix-imara-diff] should be safer to use with no unexpected panics at runtime.

[imara-diff]: https://github.com/pascalkuthe/imara-diff
[gix-imara-diff]: https://github.com/GitoxideLabs/gitoxide/tree/main/gix-imara-diff
[gitoxide]: https://github.com/GitoxideLabs/gitoxide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Replaced internal diff generation mechanism with an alternative implementation to improve code maintainability and reliability.

* **Chores**
  * Updated project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->