### PR TITLE
fix: do not fail on check for tool presence (via package managers)

### DIFF
--- a/clang-tools-manager/src/downloader/native_packages/mod.rs
+++ b/clang-tools-manager/src/downloader/native_packages/mod.rs
@@ -83,16 +83,16 @@ pub async fn try_install_package(
         for mgr in os_pkg_managers {
             log::info!("Trying to install {tool} v{min_version} using {mgr} package manager.");
             let pkg_name = mgr.get_package_name(tool);
-            if mgr.is_installed_package(&pkg_name, Some(min_version)) {
-                let path =
-                    tool.get_exe_path(&RequestedVersion::Requirement(version_req.clone()))?;
-                let version = tool.capture_version(&path)?;
-                if version_req.matches(&version) {
-                    log::info!(
-                        "Found {tool} version matching {version_req} installed via {mgr} package manager."
-                    );
-                    return Ok(Some(ClangVersion { version, path }));
-                }
+            if mgr.is_installed_package(&pkg_name, Some(min_version))
+                && let Ok(path) =
+                    tool.get_exe_path(&RequestedVersion::Requirement(version_req.clone()))
+                && let Ok(version) = tool.capture_version(&path)
+                && version_req.matches(&version)
+            {
+                log::info!(
+                    "Found {tool} version matching {version_req} installed via {mgr} package manager."
+                );
+                return Ok(Some(ClangVersion { version, path }));
             } else {
                 log::info!(
                     "{mgr} package manager does not have a version of {tool} matching {version_req} installed."

--- a/clang-tools-manager/src/downloader/native_packages/unix.rs
+++ b/clang-tools-manager/src/downloader/native_packages/unix.rs
@@ -127,12 +127,22 @@ impl PackageManager for UnixPackageManager {
             }
         }
         let output = if Self::has_sudo() && !matches!(self, UnixPackageManager::Homebrew) {
+            log::debug!(
+                "Running `sudo {} {} {package_id}`",
+                self.as_str(),
+                args.join(" ")
+            );
             Command::new("sudo")
                 .arg(self.as_str())
                 .args(args)
                 .arg(package_id.as_str())
                 .output()?
         } else {
+            log::debug!(
+                "Running `{} {} {package_id}`",
+                self.as_str(),
+                args.join(" ")
+            );
             Command::new(self.as_str())
                 .args(args)
                 .arg(package_id.as_str())
@@ -145,6 +155,10 @@ impl PackageManager for UnixPackageManager {
             if matches!(self, UnixPackageManager::Apt)
                 && let Some(version) = version
             {
+                log::error!(
+                    "Failed to install {package_id} via apt: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
                 log::info!(
                     "trying to install from official LLVM PPA repository (for Debian-based `apt` package manager)"
                 );


### PR DESCRIPTION
- ref: #342 

I added some debug logs and ran the `clang-tools` binary in a docker container. I found that the `apt` package manager support was failing because the check for any existing clang tool failed when the tool was not installed.

I converted the check for a clang tool's presence into a soft check. Meaning, if it somehow fails then just fall back to installing the clang tool as if doing a fresh/normal install.

> [!note]
> The container I used seemed to be too new; the LLVM install script does not yet support Ubuntu "resolute". But at least the `clang-tools` binary was able to fall back to static binaries. Plus, the debug and error logs are explanatory enough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation reliability by gracefully handling detection failures and proceeding with installation attempts when needed.

* **Chores**
  * Enhanced diagnostic logging for package installation operations to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->