### PR TITLE
fix: respect verbosity per GitHub Actions env var

### DIFF
--- a/cpp-linter/src/rest_client/mod.rs
+++ b/cpp-linter/src/rest_client/mod.rs
@@ -81,6 +81,10 @@ impl RestClient {
             .collect())
     }
 
+    pub fn is_debug_enabled(&self) -> bool {
+        self.client.is_debug_enabled()
+    }
+
     pub fn start_log_group(&self, name: &str) {
         self.client.start_log_group(name)
     }

--- a/cpp-linter/src/run.rs
+++ b/cpp-linter/src/run.rs
@@ -70,9 +70,7 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
 
     let mut rest_api_client = RestClient::new()?;
     set_max_level(
-        if cli.general_options.verbosity.is_debug()
-        /* || rest_api_client.debug_enabled */
-        {
+        if cli.general_options.verbosity.is_debug() || rest_api_client.is_debug_enabled() {
             LevelFilter::Debug
         } else {
             LevelFilter::Info


### PR DESCRIPTION
This was an oversight when switching to git-bot-feedback in #304.

It restores the behavior in which verbosity is auto-enabled if the `ACTIONS_STEP_DEBUG` env var is asserted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced debug logging configuration to respect REST client settings in addition to command-line verbosity options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->