### PR TITLE
docs: add cpp-linter hub badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@
 [![Docs][docs-ci-badge]][docs-site]
 [![Pre-commit-ci][pre-commit-badge]][pre-commit-ci]
 [![codecov-status][codecov-badge]][codecov-project]
-[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
+[![cpp-linter hub][cpp-linter-hub-badge][cpp-linter-hub-link]
 
+[cpp-linter-hub-badge]: https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a
+[cpp-linter-hub-link]: https://cpp-linter.github.io/
 [py-build-ci]: https://github.com/cpp-linter/cpp-linter-rs/actions/workflows/python-packaging.yml
 [py-build-badge]: https://github.com/cpp-linter/cpp-linter-rs/actions/workflows/python-packaging.yml/badge.svg
 [bin-build-badge]: https://github.com/cpp-linter/cpp-linter-rs/actions/workflows/binary-builds.yml/badge.svg

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 [![Docs][docs-ci-badge]][docs-site]
 [![Pre-commit-ci][pre-commit-badge]][pre-commit-ci]
 [![codecov-status][codecov-badge]][codecov-project]
-[![cpp-linter hub][cpp-linter-hub-badge][cpp-linter-hub-link]
+[![cpp-linter hub][cpp-linter-hub-badge]][cpp-linter-hub-link]
 
 [cpp-linter-hub-badge]: https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a
 [cpp-linter-hub-link]: https://cpp-linter.github.io/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 [![Docs][docs-ci-badge]][docs-site]
 [![Pre-commit-ci][pre-commit-badge]][pre-commit-ci]
 [![codecov-status][codecov-badge]][codecov-project]
+[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 [py-build-ci]: https://github.com/cpp-linter/cpp-linter-rs/actions/workflows/python-packaging.yml
 [py-build-badge]: https://github.com/cpp-linter/cpp-linter-rs/actions/workflows/python-packaging.yml/badge.svg


### PR DESCRIPTION
## Summary

Adds the `🏠 cpp-linter hub ← home` badge for consistent cross-repo navigation back to [cpp-linter.github.io](https://cpp-linter.github.io/).

Part of org-wide Phase 2 documentation consistency improvements.

## Changes

- Added hub badge to the badge row in README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "cpp-linter hub" badge to the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->