### PR TITLE
build: bump git-bot-feedback to v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "git-bot-feedback"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c5dcb915266b670fbc0f47f7240cfe832a0e9363e7f509ef38dec960b80824"
+checksum = "3fef7ddddaceca435d03bee13d2795201e9110b14db9610ba3846274904df41a"
 dependencies = [
  "async-trait",
  "chrono",

--- a/cpp-linter/Cargo.toml
+++ b/cpp-linter/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [dependencies.git-bot-feedback]
-version = "0.5.6"
+version = "0.6.1"
 features = ["file-changes"]
 # path = "../../git-bot-feedback"
 # git = "https://github.com/2bndy5/git-bot-feedback"

--- a/cpp-linter/src/git.rs
+++ b/cpp-linter/src/git.rs
@@ -11,7 +11,6 @@ mod test {
     use std::{
         env::{self, current_dir, set_current_dir},
         fs,
-        path::PathBuf,
         process::Command,
     };
 
@@ -104,7 +103,6 @@ mod test {
                 &LinesChangedOnly::Off.into(),
                 &base_diff,
                 ignore_staged,
-                &PathBuf::from("."),
             )
             .await
             .unwrap()

--- a/cpp-linter/src/rest_client.rs
+++ b/cpp-linter/src/rest_client.rs
@@ -2,7 +2,7 @@
 
 use std::{
     env,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, Mutex},
 };
 
@@ -69,7 +69,6 @@ impl RestClient {
         lines_changed_only: &LinesChangedOnly,
         base_diff: &Option<String>,
         ignore_index: bool,
-        repo_root: &Path,
     ) -> Result<Vec<FileObj>, ClientError> {
         let files = self
             .client
@@ -89,14 +88,7 @@ impl RestClient {
                     .map(|hunk| hunk.start..=hunk.end)
                     .collect();
                 let file_path = PathBuf::from(file_name);
-                FileObj::from(
-                    file_path
-                        .strip_prefix(repo_root)
-                        .map(PathBuf::from)
-                        .unwrap_or(file_path),
-                    diff_lines.added_lines.clone(),
-                    diff_chunks,
-                )
+                FileObj::from(file_path, diff_lines.added_lines.clone(), diff_chunks)
             })
             .collect())
     }

--- a/cpp-linter/src/run.rs
+++ b/cpp-linter/src/run.rs
@@ -82,7 +82,8 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
             .collect::<Vec<&str>>(),
         None,
     );
-    file_filter.parse_submodules();
+    let gitmodules = cli.source_options.repo_root.join(".gitmodules");
+    file_filter.parse_submodules(Some(gitmodules.as_path()));
     if let Some(files) = &cli.not_ignored {
         file_filter.not_ignored.extend(files.clone());
     }
@@ -101,7 +102,6 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
     }
 
     rest_api_client.start_log_group("Get list of specified source files");
-    let repo_root_path = PathBuf::from(&cli.source_options.repo_root);
     let files = if !matches!(cli.source_options.lines_changed_only, LinesChangedOnly::Off)
         || cli.source_options.files_changed_only
     {
@@ -112,7 +112,6 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
                 &cli.source_options.lines_changed_only.clone().into(),
                 &cli.source_options.diff_base,
                 cli.source_options.ignore_index,
-                &repo_root_path,
             )
             .await?
     } else {
@@ -122,12 +121,7 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
             .into_iter()
             .map(|file_name| {
                 let file_path = PathBuf::from(&file_name);
-                FileObj::new(
-                    file_path
-                        .strip_prefix(&repo_root_path)
-                        .map(PathBuf::from)
-                        .unwrap_or(file_path),
-                )
+                FileObj::new(file_path)
             })
             .collect();
         if is_pr && (cli.feedback_options.tidy_review || cli.feedback_options.format_review) {
@@ -137,7 +131,6 @@ pub async fn run_main(args: Vec<String>) -> Result<()> {
                     &LinesChangedOnly::Off.into(),
                     &cli.source_options.diff_base,
                     cli.source_options.ignore_index,
-                    &repo_root_path,
                 )
                 .await?;
             for changed_file in changed_files {

--- a/cpp-linter/tests/paginated_changed_files.rs
+++ b/cpp-linter/tests/paginated_changed_files.rs
@@ -143,7 +143,6 @@ async fn get_paginated_changes(lib_root: &Path, tmp_dir: &TempDir, test_params: 
             &LinesChangedOnly::Off,
             &None::<String>,
             false,
-            tmp_dir.path(),
         )
         .await;
     match files {

--- a/cpp-linter/tests/paginated_changed_files.rs
+++ b/cpp-linter/tests/paginated_changed_files.rs
@@ -138,12 +138,7 @@ async fn get_paginated_changes(lib_root: &Path, tmp_dir: &TempDir, test_params: 
 
     let file_filter = FileFilter::new(&[], &["cpp", "hpp"], None);
     let files = client
-        .get_list_of_changed_files(
-            &file_filter,
-            &LinesChangedOnly::Off,
-            &None::<String>,
-            false,
-        )
+        .get_list_of_changed_files(&file_filter, &LinesChangedOnly::Off, &None::<String>, false)
         .await;
     match files {
         Err(e) => {


### PR DESCRIPTION
Moves some much needed logic downstream into git-bot-feedback: `FileFilter::walk_dir()` better supports absolute paths by stripping `repo_root` paths prefixed to the returned results. Also applied to a given relative `root_path`.

Also removes a redundant patch to `get_changed_files()`. The results returned there are already relative to the repo root, so there's no need to strip a prefixed path that isn't there.

follow-up to #349