### PR TITLE
fix: cache the versions.json in build script

### DIFF
--- a/.github/workflows/binary-builds.yml
+++ b/.github/workflows/binary-builds.yml
@@ -186,7 +186,7 @@ jobs:
   publish:
     if: startswith(github.ref, 'refs/tags/cpp-linter/v') || startswith(github.ref, 'refs/tags/clang-tools-manager/v')
     runs-on: ubuntu-latest
-    needs: [create-assets]
+    needs: [create-assets, seed-build-script]
     permissions:
       id-token: write
       contents: write
@@ -210,6 +210,12 @@ jobs:
         run: |
           files=$(ls dist/${BIN_NAME}*)
           gh release upload "${GIT_REF}" ${files}
+      - name: Restore build script seed
+        if: startsWith(github.ref_name, 'clang-tools-manager/v')
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.seed-build-script.outputs.artifact-name }}
+          path: clang-tools-manager
       - name: Establish provenance
         id: auth
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4

--- a/clang-tools-manager/Cargo.toml
+++ b/clang-tools-manager/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+# Include a pre-seeded versions.json file in package published to crates.io.
+# This is invalidated after 24 hours, but it allows docs.rs builds to succeed.
+include = ["versions.json", "src/**", "Cargo.toml", "README.md", "build.rs", "tests/**"]
 
 [[bin]]
 path = "src/main.rs"
@@ -21,7 +24,7 @@ required-features = ["bin"]
 [dependencies]
 anyhow = { workspace = true, optional = true }
 blake2 = "0.10.6"
-clap = { workspace = true, features = ["derive", "env"], optional = true }
+clap = { workspace = true, features = ["derive"], optional = true }
 colored = { workspace = true, optional = true }
 directories = "6.0.0"
 log = { workspace = true }

--- a/clang-tools-manager/build.rs
+++ b/clang-tools-manager/build.rs
@@ -1,4 +1,9 @@
-use std::{fs, path::PathBuf, time::Duration};
+use std::{
+    fs,
+    io::Write,
+    path::PathBuf,
+    time::{Duration, SystemTime},
+};
 
 use reqwest::blocking::ClientBuilder;
 
@@ -11,11 +16,19 @@ struct VersionInfo {
 }
 fn main() {
     let pre_seed = PathBuf::from("versions.json");
-    let version_info_str = if pre_seed.exists() {
+    let version_info_str = if pre_seed.exists()
+        && let Ok(metadata) = fs::metadata(&pre_seed)
+        && metadata.modified().is_ok_and(|d| {
+            SystemTime::now()
+                .duration_since(d)
+                // repopulate cached file in case of error
+                .unwrap_or(Duration::from_hours(25))
+                < Duration::from_hours(24)
+        }) {
         println!("cargo:warning=Using pre-seeded version info from {pre_seed:?}");
         fs::read_to_string(&pre_seed).unwrap()
     } else {
-        ClientBuilder::new()
+        let versions = ClientBuilder::new()
             .user_agent("cpp-linter-rs/clang-tools-manager")
             .timeout(Duration::from_secs(30))
             .build()
@@ -24,7 +37,16 @@ fn main() {
             .send()
             .unwrap()
             .text()
-            .unwrap()
+            .unwrap();
+        let mut cached_seed = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&pre_seed)
+            .unwrap();
+        cached_seed.write_all(versions.as_bytes()).unwrap();
+        cached_seed.set_modified(SystemTime::now()).unwrap();
+        versions
     };
     let version_info: VersionInfo = serde_json::from_str(&version_info_str).unwrap();
     let (min_ver, max_ver) = {


### PR DESCRIPTION
resolves #365

This allows publishing clang-tools-manager crate with a cached versions.json file, so the docs.rs build can succeed. The cached file is invalid after 24 hours, meaning the cached file is updated at least once a day.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened CI/CD publishing pipeline with improved job dependencies and artifact management for binary releases
  * Enhanced build script with intelligent local version data caching to improve overall build efficiency and reduce external requests
  * Updated package metadata configuration and optimized dependency features for improved distribution and compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->