### PR TITLE
fix: pass `--extra-arg`s to clang-tidy properly

### DIFF
--- a/cpp-linter/src/clang_tools/clang_tidy.rs
+++ b/cpp-linter/src/clang_tools/clang_tidy.rs
@@ -294,7 +294,12 @@ pub fn run_clang_tidy(
         cmd.args(["-p", &db.to_string_lossy()]);
     }
     for arg in &clang_params.extra_args {
-        cmd.args(["--extra-arg", format!("\"{}\"", arg).as_str()]);
+        // Use `--extra-arg=...` syntax to prevent values getting
+        // interpreted as a clang-tidy options.
+        // At this point, values should already be split by
+        // whitespace in `ClangParams::from(&cli)` via
+        // `crate::cli::convert_extra_arg_val()`.
+        cmd.arg(format!("--extra-arg={arg}").as_str());
     }
     let file_name = file.name.to_string_lossy().to_string();
     let ranges = file.get_ranges(&clang_params.lines_changed_only);
@@ -390,6 +395,10 @@ pub fn run_clang_tidy(
         &clang_params.database_json,
         &clang_params.repo_root,
     )?;
+    logs.push((
+        log::Level::Debug,
+        format!("Parsed {} clang-tidy notifications", notes.len()),
+    ));
 
     let tidy_advice = TidyAdvice { notes };
     file.patched_path = Some(cache_patch_path.to_path_buf());
@@ -474,7 +483,7 @@ mod test {
     // ***************** test for regex parsing of clang-tidy stdout
 
     #[test]
-    fn test_capture() {
+    fn regex_capture() {
         let src = "tests/demo/demo.hpp:11:11: \
         warning: use a trailing return type for this function \
         [modernize-use-trailing-return-type,-warnings-as-errors]";
@@ -540,8 +549,9 @@ mod test {
             .expect("expected a log message about invoked clang-tidy command")
             .split(' ')
             .collect::<Vec<&str>>();
+        println!("args: {:?}", args);
         for arg in &extra_args {
-            let extra_arg = format!("\"{arg}\"");
+            let extra_arg = format!("--extra-arg={arg}");
             assert!(args.contains(&extra_arg.as_str()));
         }
     }

--- a/cpp-linter/src/cli/structs.rs
+++ b/cpp-linter/src/cli/structs.rs
@@ -4,7 +4,7 @@ use std::{fmt::Display, path::PathBuf};
 use clap::{ValueEnum, builder::PossibleValue};
 
 #[cfg(feature = "bin")]
-use super::Cli;
+use super::{Cli, convert_extra_arg_val};
 use crate::clang_tools::clang_tidy::CompilationUnit;
 
 use git_bot_feedback::FileFilter;
@@ -275,7 +275,7 @@ impl From<&Cli> for ClangParams {
             tidy_checks: args.tidy_options.tidy_checks.clone(),
             lines_changed_only: args.source_options.lines_changed_only.clone(),
             database,
-            extra_args: args.tidy_options.extra_arg.clone(),
+            extra_args: convert_extra_arg_val(&args.tidy_options.extra_arg),
             database_json: None,
             style: args.format_options.style.clone(),
             clang_tidy_command: None,


### PR DESCRIPTION
1. The conversion function was not being used in production code.
2. clang-tidy was finding the `--extra-arg` value as an unrecognized option. Prefer using `--extra-arg=...` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified extra argument handling format for clang-tidy invocations.
  * Updated argument processing logic.

* **Tests**
  * Updated test assertions to match new argument formatting.
  * Added debug logging for parsed arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->