### PR TITLE
fix: add context lines to generated patch

### DIFF
--- a/cpp-linter/src/common_fs.rs
+++ b/cpp-linter/src/common_fs.rs
@@ -192,8 +192,7 @@ impl FileObj {
         repo_root: &Path,
     ) -> Result<(), FileObjError> {
         let printer = BasicLineDiffPrinter(&input.interner);
-        let mut diff_config = UnifiedDiffConfig::default();
-        diff_config.context_len(0);
+        let diff_config = UnifiedDiffConfig::default();
         let unified_diff = diff.unified_diff(&printer, diff_config, input).to_string();
         if !unified_diff.is_empty() {
             let patch_path_parent = repo_root.join(ClangParams::CACHE_DIR);

--- a/cpp-linter/tests/comments.rs
+++ b/cpp-linter/tests/comments.rs
@@ -322,6 +322,14 @@ async fn setup(lib_root: &Path, tmp_dir: &TempDir, test_params: &TestParams) {
             };
             println!("{style}{l}{style:#}");
         }
+
+        let apply_patch_status = std::process::Command::new("git")
+            .arg("apply")
+            .arg(patch_path)
+            .current_dir(tmp_dir.path())
+            .status()
+            .expect("Failed to execute `git apply` command.");
+        assert!(apply_patch_status.success());
     }
 
     let summary_out_file_abs_path = if test_params.relative_summary_out_file {


### PR DESCRIPTION
Apparently, `git apply` uses context lines in the patch to find a match for changed lines. Previously, we weren't adding context lines to keep the patch size minimal.

As a bonus, `git apply` does not require being used in a git repository. This means I can `git apply` any generated patch in the integration tests about thread comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the generated patch output so it may include more surrounding context when applied.
  * The test workflow now verifies that generated patches can be applied successfully, helping catch issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->