### PR TITLE
fix: updates for latest static binaries

### DIFF
--- a/clang-tools-manager/src/downloader/hashing.rs
+++ b/clang-tools-manager/src/downloader/hashing.rs
@@ -15,21 +15,25 @@ use std::{fs, io::Read, num::NonZero, path::Path};
 #[derive(Debug, Clone)]
 pub enum HashAlgorithm {
     /// SHA-256 hash algorithm with the expected checksum value.
+    ///
+    /// Used by the PyPI downloader.
     Sha256(String),
 
     /// BLAKE2b-256 hash algorithm with the expected checksum value.
+    ///
+    /// Used by the PyPI downloader.
     Blake2b256(String),
 
     /// SHA-512 hash algorithm with the expected checksum value.
-    #[cfg(any(
-        // Windows support is only for x86_64 architecture (for now)
-        all(target_os = "windows", target_arch = "x86_64"),
-        // Linux and macOS support only x86_64 and aarch64 architectures
+    ///
+    /// Used exclusively by the static distribution downloader.
+    #[cfg(
+        // Windows, Linux, and MacOS support only x86_64 and aarch64 architectures
         all(
-            any(target_os = "linux", target_os = "macos"),
+            any(target_os = "windows", target_os = "linux", target_os = "macos"),
             any(target_arch = "x86_64", target_arch = "aarch64")
-        ),
-    ))]
+        )
+    )]
     Sha512(String),
 }
 
@@ -85,15 +89,13 @@ impl HashAlgorithm {
                 let hasher = Blake2b::<U32>::new();
                 Self::hash_file(hasher, file_path, expected)
             }
-            #[cfg(any(
-                // Windows support is only for x86_64 architecture (for now)
-                all(target_os = "windows", target_arch = "x86_64"),
-                // Linux and macOS support only x86_64 and aarch64 architectures
+            #[cfg(
+                // Windows, Linux, and MacOS support only x86_64 and aarch64 architectures
                 all(
-                    any(target_os = "linux", target_os = "macos"),
+                    any(target_os = "windows", target_os = "linux", target_os = "macos"),
                     any(target_arch = "x86_64", target_arch = "aarch64")
                 ),
-            ))]
+            )]
             HashAlgorithm::Sha512(expected) => {
                 use sha2::{Digest, Sha512};
 

--- a/clang-tools-manager/src/downloader/static_dist.rs
+++ b/clang-tools-manager/src/downloader/static_dist.rs
@@ -120,7 +120,7 @@ mod supported_platform {
 
         /// Verifies the SHA512 checksum of the downloaded file.
         ///
-        /// The expected checksum is extracted from another downloaded `*.sha512sum` file
+        /// The expected checksum is extracted from another downloaded `SHA512SUMS` file
         /// (pointed to by `sha512_path`).
         fn verify_sha512(
             file_path: &Path,

--- a/clang-tools-manager/src/downloader/static_dist.rs
+++ b/clang-tools-manager/src/downloader/static_dist.rs
@@ -88,6 +88,7 @@ mod unsupported_platform {
 mod supported_platform {
     use std::{
         fs,
+        io::{BufRead, BufReader},
         ops::RangeInclusive,
         path::{Path, PathBuf},
     };
@@ -127,13 +128,21 @@ mod supported_platform {
             tool: &str,
             sha512_path: &Path,
         ) -> Result<(), StaticDistDownloadError> {
-            let checksum_file_content = fs::read_to_string(sha512_path)?;
-            let expected = checksum_file_content
-                .lines()
-                .find(|line| line.ends_with(tool))
-                .and_then(|line| line.split(' ').next())
-                .ok_or(StaticDistDownloadError::Sha512Corruption)?;
-            HashAlgorithm::Sha512(expected.to_string()).verify(file_path)?;
+            let expected = {
+                let checksum_file_handle = fs::File::open(sha512_path)?;
+                let checksum_file_content = BufReader::new(checksum_file_handle);
+                let mut found = None;
+                for line in checksum_file_content.lines() {
+                    let line = line?;
+                    if line.ends_with(tool) {
+                        found = line.split(' ').next().map(|s| s.trim().to_string());
+                        break;
+                    }
+                }
+                found
+            }
+            .ok_or(StaticDistDownloadError::Sha512Corruption)?;
+            HashAlgorithm::Sha512(expected).verify(file_path)?;
             Ok(())
         }
 

--- a/clang-tools-manager/src/downloader/static_dist.rs
+++ b/clang-tools-manager/src/downloader/static_dist.rs
@@ -19,7 +19,7 @@ pub enum StaticDistDownloadError {
     UnsupportedVersion,
 
     /// The static binaries are only built for
-    /// x86_64 and aarch64 architecture on Linux MacOS, and Windows.
+    /// x86_64 and aarch64 architecture on Linux, MacOS, and Windows.
     #[error("The static binaries are not built for {OS} {ARCH} architecture")]
     UnsupportedArchitecture,
 

--- a/clang-tools-manager/src/downloader/static_dist.rs
+++ b/clang-tools-manager/src/downloader/static_dist.rs
@@ -19,8 +19,7 @@ pub enum StaticDistDownloadError {
     UnsupportedVersion,
 
     /// The static binaries are only built for
-    /// x86_64 and aarch64 architecture on Linux MacOS, and
-    /// Windows (not aarch64 for Windows currently).
+    /// x86_64 and aarch64 architecture on Linux MacOS, and Windows.
     #[error("The static binaries are not built for {OS} {ARCH} architecture")]
     UnsupportedArchitecture,
 
@@ -54,11 +53,9 @@ impl StaticDistDownloader {
 }
 
 #[cfg(any(
-    // Windows support is only for x86_64 architecture (for now)
-    all(target_os = "windows", not(target_arch = "x86_64")),
-    // Linux and macOS support only x86_64 and aarch64 architectures
+    // Windows, Linux, and MacOS support only x86_64 and aarch64 architectures
     all(
-        any(target_os = "linux", target_os = "macos"),
+        any(target_os = "windows", target_os = "linux", target_os = "macos"),
         not(any(target_arch = "x86_64", target_arch = "aarch64"))
     ),
     // Any OS other than Windows, Linux, or macOS is unsupported
@@ -81,15 +78,13 @@ mod unsupported_platform {
     }
 }
 
-#[cfg(any(
-    // Windows support is only for x86_64 architecture (for now)
-    all(target_os = "windows", target_arch = "x86_64"),
-    // Linux and macOS support only x86_64 and aarch64 architectures
+#[cfg(
+    // Windows, Linux, and MacOS support only x86_64 and aarch64 architectures
     all(
-        any(target_os = "linux", target_os = "macos"),
+        any(target_os = "windows", target_os = "linux", target_os = "macos"),
         any(target_arch = "x86_64", target_arch = "aarch64")
     ),
-))]
+)]
 mod supported_platform {
     use std::{
         fs,
@@ -129,12 +124,14 @@ mod supported_platform {
         /// (pointed to by `sha512_path`).
         fn verify_sha512(
             file_path: &Path,
+            tool: &str,
             sha512_path: &Path,
         ) -> Result<(), StaticDistDownloadError> {
             let checksum_file_content = fs::read_to_string(sha512_path)?;
             let expected = checksum_file_content
-                .split(' ')
-                .next()
+                .lines()
+                .find(|line| line.ends_with(tool))
+                .and_then(|line| line.split(' ').next())
                 .ok_or(StaticDistDownloadError::Sha512Corruption)?;
             HashAlgorithm::Sha512(expected.to_string()).verify(file_path)?;
             Ok(())
@@ -169,15 +166,14 @@ mod supported_platform {
                 "linux"
             };
 
-            let base_url = format!(
-                "{CLANG_TOOLS_REPO}/releases/download/{CLANG_TOOLS_TAG}/{tool}-{ver_str}_{platform}-{arch}",
-            );
+            let base_url = format!("{CLANG_TOOLS_REPO}/releases/download/{CLANG_TOOLS_TAG}/",);
             let suffix = if cfg!(target_os = "windows") {
                 ".exe"
             } else {
                 ""
             };
-            let url = Url::parse(format!("{base_url}{suffix}").as_str())?;
+            let tool_url_path = format!("{tool}-{ver_str}_{platform}-{arch}{suffix}");
+            let url = Url::parse(format!("{base_url}{tool_url_path}").as_str())?;
             let cache_path = Self::get_cache_dir();
             let bin_name = format!("{tool}-{ver_str}{suffix}");
             let download_path = match directory {
@@ -196,22 +192,18 @@ mod supported_platform {
                 #[cfg(unix)]
                 super::super::chmod_file(&download_path, None)?;
             }
-            let sha512_cache_path = cache_path
-                .join("static_dist")
-                .join(format!("{tool}-{ver_str}.sha512"));
+            let sha512_cache_path = cache_path.join("static_dist").join("SHA512SUMS");
             if sha512_cache_path.exists() {
                 log::info!(
-                    "Using cached SHA512 checksum for {tool} version {ver_str} from {:?}",
+                    "Using cached SHA512 checksums for static binaries from {:?}",
                     sha512_cache_path.to_string_lossy()
                 );
             } else {
-                let sha512_url = Url::parse(format!("{base_url}{suffix}.sha512sum").as_str())?;
-                log::info!(
-                    "Downloading SHA512 checksum for {tool} version {ver_str} from {sha512_url}"
-                );
+                let sha512_url = Url::parse(format!("{base_url}SHA512SUMS").as_str())?;
+                log::info!("Downloading SHA512 checksum for static binaries from {sha512_url}");
                 download(&sha512_url, &sha512_cache_path, 10).await?;
             }
-            Self::verify_sha512(&download_path, &sha512_cache_path)?;
+            Self::verify_sha512(&download_path, &tool_url_path, &sha512_cache_path)?;
             file_lock.unlock()?;
             Ok(download_path)
         }

--- a/cpp-linter/src/clang_tools/clang_tidy.rs
+++ b/cpp-linter/src/clang_tools/clang_tidy.rs
@@ -306,7 +306,7 @@ pub fn run_clang_tidy(
     if !ranges.is_empty() {
         let filter = format!(
             "[{{\"name\":{:?},\"lines\":{:?}}}]",
-            &file_name.replace('/', if OS == "windows" { "\\" } else { "/" }),
+            file_name.replace('/', if OS == "windows" { "\\" } else { "/" }),
             ranges
                 .iter()
                 .map(|r| [r.start(), r.end()])

--- a/cpp-linter/src/common_fs.rs
+++ b/cpp-linter/src/common_fs.rs
@@ -258,15 +258,15 @@ impl FileObj {
                     }
                     let mut suggestion = format!(
                         "### clang-tidy diagnostic\n**{file_name}:{}:{}** {}: [{}]\n\n> {}\n",
-                        &note.line,
-                        &note.cols,
-                        &note.severity,
+                        note.line,
+                        note.cols,
+                        note.severity,
                         note.diagnostic_link(),
-                        &note.rationale
+                        note.rationale
                     );
                     if !note.suggestion.is_empty() {
                         suggestion.push_str(
-                            format!("\n```{file_ext}\n{}\n```\n", &note.suggestion.join("\n"))
+                            format!("\n```{file_ext}\n{}\n```\n", note.suggestion.join("\n"))
                                 .as_str(),
                         );
                     }

--- a/docs/src/lib.rs
+++ b/docs/src/lib.rs
@@ -35,7 +35,7 @@ fn generate_cli_doc(metadata: HashMap<String, HashMap<String, Py<PyAny>>>) -> Py
         out.push_str(
             format!(
                 "{}\n",
-                &cmd.get_about()
+                cmd.get_about()
                     .ok_or(PyValueError::new_err(format!(
                         "{} command has no help message",
                         cmd.get_name()


### PR DESCRIPTION
- use unified SHA512 checksums file
- download binaries for windows arm64

also includes some changes that satisify new clippy lints (per Rust v1.97.0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded static binary downloads to support both x86_64 and aarch64 on Windows, Linux, and macOS.

* **Bug Fixes**
  * Improved static distribution verification by matching downloads against a shared `SHA512SUMS` entry.
  * Updated SHA-512 support selection for the relevant platform/architecture targets.

* **Documentation / Improvements**
  * Refined clang-tidy output formatting for generated suggestions and line filtering.
  * Adjusted CLI subcommand help text generation to avoid minor formatting inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->